### PR TITLE
fix: add missing version link for v0.4.1 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Monitoring: Prometheus, Grafana, ELK, DataDog
 - Security: OWASP Top 10, SAST tools
 
+[0.4.1]: https://github.com/jeffallan/claude-skills/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jeffallan/claude-skills/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/jeffallan/claude-skills/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jeffallan/claude-skills/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
## Description
Adds the missing version comparison link for v0.4.1 in CHANGELOG.md.

## Changes
- Added `[0.4.1]: https://github.com/jeffallan/claude-skills/compare/v0.4.0...v0.4.1` to the version links section

## Testing
- Verified link format follows Keep a Changelog conventions
- Verified correct placement in chronological order
- All other version links remain intact

Fixes missing link reference for version 0.4.1.