### PR TITLE
docs: add Agent Skills CLI installation method

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,7 +29,7 @@ npx skills add jeffallan/claude-skills
 
 ### Install via Agent Skills CLI
 ```bash
-npx agent-skills-cli install @Jeffallan/claude-skills
+npx agent-skills-cli@latest add @Jeffallan/claude-skills
 ```
 
 > **Note:** This method installs skills only. Slash commands (`/common-ground`, `/project:*`) are not included. Installs to 42+ AI agents including Claude, Cursor, Copilot, Windsurf, and more. [Learn more](https://www.agentskills.in)


### PR DESCRIPTION
## Summary

Adds Agent Skills CLI as an alternative installation method in QUICKSTART.md, as requested in #149.

## Changes

- Added "Install via Agent Skills CLI" section under "Installation (Choose One)"
- Follows the existing `skills.sh` formatting pattern
- Includes note about skills-only installation (slash commands not included)

## What is Agent Skills CLI?

[Agent Skills CLI](https://github.com/Karanjot786/agent-skills-cli) distributes skills across 42+ AI agents (Claude, Cursor, Copilot, Windsurf, Cline, and more) with a single command:

```bash
npx agent-skills-cli@latest add @Jeffallan/claude-skills
```