### PR TITLE
docs: add multi-skill workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,7 @@ Fullstack engineering, security engineering, compliance, and technical due dilig
 ---
 
 **Built for Claude Code** | **<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> Workflows** | **<!-- REFERENCE_COUNT -->365<!-- /REFERENCE_COUNT --> Reference Files** | **<!-- SKILL_COUNT -->66<!-- /SKILL_COUNT --> Skills**
+
+## Examples
+
+See the `examples/` directory for real-world workflow walkthroughs demonstrating multi-skill usage.

--- a/examples/ADDING_AUTHENTICATION.md
+++ b/examples/ADDING_AUTHENTICATION.md
@@ -1,0 +1,172 @@
+# Adding Authentication to an Existing Application
+
+> **Skills used:** Secure Code Guardian, Framework Expert, Test Master, Security Reviewer  
+> **Difficulty:** Intermediate  
+> **Estimated time:** 2–3 hours  
+
+---
+
+## Overview
+
+This walkthrough demonstrates how multiple skills work together to securely add authentication to an existing REST API.
+
+The goal is to:
+
+- Protect sensitive endpoints
+- Implement JWT-based authentication
+- Validate security implementation
+- Prevent common vulnerabilities
+
+---
+
+## Scenario
+
+We have an existing task management API with public endpoints:
+
+- GET /tasks
+- POST /tasks
+- PATCH /tasks/{id}
+- DELETE /tasks/{id}
+
+Currently, anyone can access these endpoints.
+
+We need to:
+
+1. Add user authentication
+2. Protect routes
+3. Prevent unauthorized access
+4. Ensure secure implementation
+
+---
+
+## Step 1 — Define Security Requirements with Secure Code Guardian
+
+### Invoke
+
+Define authentication requirements for securing a REST API using JWT.
+
+### What Secure Code Guardian Provides
+
+- Authentication flow design
+- Password handling recommendations
+- Token expiration policies
+- Security best practices
+
+### Example Output (Excerpt)
+
+    Requirements:
+    - Passwords must be hashed using bcrypt.
+    - Access tokens must expire after 15 minutes.
+    - Refresh tokens should be implemented.
+    - Protected routes must validate JWT before execution.
+
+This establishes security-first design principles.
+
+---
+
+## Step 2 — Implement JWT Authentication with Framework Expert
+
+### Invoke
+
+Generate FastAPI JWT authentication implementation with login and protected routes.
+
+### What Framework Expert Provides
+
+- User model updates
+- Password hashing logic
+- Login endpoint
+- JWT creation and validation
+- Route protection via dependencies
+
+### Example Implementation
+
+    from fastapi import Depends, HTTPException
+    from jose import jwt
+
+    @app.post("/login")
+    async def login(user: UserLogin):
+        # Validate credentials
+        # Generate JWT token
+        return {"access_token": token}
+
+    @app.get("/tasks")
+    async def list_tasks(current_user: User = Depends(get_current_user)):
+        return await fetch_tasks()
+
+Protected routes now require a valid token.
+
+---
+
+## Step 3 — Validate Security with Test Master
+
+### Invoke
+
+Generate test cases for authentication and authorization logic.
+
+### What Test Master Provides
+
+- Valid login tests
+- Invalid credential tests
+- Expired token tests
+- Unauthorized access tests
+
+### Example Test Snippet
+
+    def test_protected_route_requires_token(client):
+        response = client.get("/tasks")
+        assert response.status_code == 401
+
+    def test_login_returns_token(client):
+        response = client.post("/login", json={"username": "user", "password": "pass"})
+        assert "access_token" in response.json()
+
+This ensures access control works as intended.
+
+---
+
+## Step 4 — Review Security with Security Reviewer
+
+### Invoke
+
+Review authentication implementation for vulnerabilities.
+
+### What Security Reviewer Provides
+
+- Token validation review
+- Secret key storage recommendations
+- Detection of hardcoded credentials
+- CSRF and replay attack considerations
+
+### Example Recommendations
+
+    - Store JWT secret in environment variables.
+    - Enable HTTPS in production.
+    - Implement token revocation for logout.
+    - Limit login attempts to prevent brute force attacks.
+
+This final review strengthens the implementation.
+
+---
+
+## Skill Flow Summary
+
+1. Secure Code Guardian defines authentication architecture.
+2. Framework Expert implements JWT-based authentication.
+3. Test Master verifies correct authorization behavior.
+4. Security Reviewer validates the system against vulnerabilities.
+
+---
+
+## Key Takeaways
+
+- Authentication must be designed before implementation.
+- Route protection should use framework-native patterns.
+- Testing prevents broken access control.
+- Security review ensures production readiness.
+- Multi-skill chaining leads to safer deployments.
+
+---
+
+## Final Result
+
+The application now supports secure JWT-based authentication with protected routes, validated access control, and production-ready security practices.

--- a/examples/DEBUGGING_PRODUCTION_ISSUE.md
+++ b/examples/DEBUGGING_PRODUCTION_ISSUE.md
@@ -1,0 +1,169 @@
+# Debugging a Production Issue
+
+> **Skills used:** Debugging Wizard, Monitoring Expert, Framework Expert, Test Master  
+> **Difficulty:** Intermediate  
+> **Estimated time:** 1–3 hours  
+
+---
+
+## Overview
+
+This walkthrough demonstrates how multiple skills collaborate to diagnose, reproduce, fix, and validate a production issue in a web application.
+
+The goal is to show how structured debugging prevents guesswork and reduces time-to-resolution.
+
+---
+
+## Scenario
+
+A production API endpoint `/tasks` is returning intermittent 500 errors.
+
+Users report:
+
+- Random failures when fetching tasks
+- Occasional timeout responses
+- Inconsistent behavior under load
+
+We need to:
+
+1. Identify the root cause
+2. Fix the issue
+3. Prevent regression
+
+---
+
+## Step 1 — Analyze Logs with Monitoring Expert
+
+### Invoke
+
+Show recent production errors and performance metrics for the `/tasks` endpoint.
+
+### What Monitoring Expert Provides
+
+- Error traces
+- Stack traces
+- Request timing data
+- Resource usage patterns
+
+### Example Output (Excerpt)
+
+    Error: sqlalchemy.exc.TimeoutError
+    QueuePool limit reached
+    Endpoint: GET /tasks
+    Average response time: 3.4s
+    Peak DB connections: 100%
+
+This suggests database connection pool exhaustion.
+
+---
+
+## Step 2 — Investigate Root Cause with Debugging Wizard
+
+### Invoke
+
+Analyze this SQLAlchemy TimeoutError and identify potential causes.
+
+### What Debugging Wizard Provides
+
+- Root cause analysis
+- Misconfiguration detection
+- Concurrency issues explanation
+- Suggested fixes
+
+### Example Output (Excerpt)
+
+    Possible Causes:
+    - Connection pool size too small
+    - Connections not properly closed
+    - Blocking synchronous calls in async context
+
+    Recommended Fix:
+    Ensure proper async session handling and increase pool size.
+
+The issue appears to be improper session cleanup.
+
+---
+
+## Step 3 — Inspect Code with Framework Expert
+
+### Invoke
+
+Review FastAPI async database usage and identify incorrect session handling.
+
+### What Framework Expert Provides
+
+- Code-level analysis
+- Best practices for async database sessions
+- Correct dependency injection pattern
+
+### Problematic Code
+
+    async def list_tasks(db: AsyncSession):
+        tasks = await db.execute(select(Task))
+        return tasks.scalars().all()
+
+### Suggested Fix
+
+    async def list_tasks(db: AsyncSession = Depends(get_db)):
+        result = await db.execute(select(Task))
+        return result.scalars().all()
+
+Ensuring sessions are properly managed via dependency injection prevents connection leaks.
+
+---
+
+## Step 4 — Validate Fix with Test Master
+
+### Invoke
+
+Generate load test and regression tests for the `/tasks` endpoint.
+
+### What Test Master Provides
+
+- Concurrency tests
+- Stress test scripts
+- Edge case validation
+- Regression coverage
+
+### Example Test Snippet
+
+    def test_tasks_endpoint_under_load(client):
+        responses = [client.get("/tasks") for _ in range(50)]
+        assert all(r.status_code == 200 for r in responses)
+
+This ensures the timeout issue does not reoccur.
+
+---
+
+## Step 5 — Confirm Stability
+
+After deploying the fix:
+
+- Monitor database connection usage
+- Track response times
+- Validate error rate drops to zero
+
+---
+
+## Skill Flow Summary
+
+1. Monitoring Expert identifies abnormal production behavior.
+2. Debugging Wizard analyzes the root cause.
+3. Framework Expert provides correct implementation patterns.
+4. Test Master validates the fix and prevents regression.
+
+---
+
+## Key Takeaways
+
+- Structured debugging reduces guesswork.
+- Monitoring data should guide investigation.
+- Framework best practices prevent resource leaks.
+- Testing is critical after production fixes.
+- Skill chaining creates a disciplined incident response workflow.
+
+---
+
+## Final Result
+
+The `/tasks` endpoint is stabilized, database connections are properly managed, and regression tests ensure the issue does not return.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,64 @@
+# Workflow Examples
+
+This directory contains practical, step-by-step workflow examples demonstrating how multiple skills work together to solve real development tasks.
+
+While `SKILLS_GUIDE.md` explains what each skill does, these examples show **how skills chain together in real-world scenarios**.
+
+---
+
+## Why These Examples Exist
+
+New users often understand individual skills but struggle with:
+
+- When to use which skill
+- How to sequence them
+- How outputs from one skill feed into another
+- How to structure real development workflows
+
+These examples bridge that gap.
+
+---
+
+## How to Use These Examples
+
+Each example includes:
+
+- Skills used
+- Step-by-step invocation
+- Sample outputs
+- Code excerpts
+- Explanation of skill chaining
+
+You can:
+
+- Follow the walkthrough directly
+- Adapt the structure to your own project
+- Use it as a template for your team workflows
+
+---
+
+## Available Examples
+
+### 1. REST_API_FROM_SCRATCH.md
+Build a complete REST API from requirements to deployment.
+
+**Skills demonstrated:**
+Feature Forge → API Designer → FastAPI Expert → Test Master → DevOps Engineer
+
+---
+
+### 2. DEBUGGING_PRODUCTION_ISSUE.md
+Investigate and resolve a real-world production bug.
+
+**Skills demonstrated:**
+Debugging Wizard → Monitoring Expert → Framework Skill → Test Master
+
+---
+
+### 3. ADDING_AUTHENTICATION.md
+Secure an existing application using structured security practices.
+
+**Skills demonstrated:**
+Secure Code Guardian → Framework Skill → Test Master → Security Reviewer
+
+---

--- a/examples/REST_API_FROM_SCRATCH.md
+++ b/examples/REST_API_FROM_SCRATCH.md
@@ -1,0 +1,181 @@
+# Building a REST API from Scratch
+
+> **Skills used:** Feature Forge, API Designer, FastAPI Expert, Test Master, DevOps Engineer  
+> **Difficulty:** Intermediate  
+> **Estimated time:** 2–4 hours  
+
+---
+
+## Overview
+
+This walkthrough demonstrates how multiple skills work together to design, implement, test, and deploy a production-ready REST API for a task management system.
+
+Each skill builds on the output of the previous one.
+
+---
+
+## Scenario
+
+We want to build a Task Management API that allows users to:
+
+- Create tasks
+- List tasks
+- Mark tasks as completed
+- Delete tasks
+
+---
+
+## Step 1 — Define Requirements with Feature Forge
+
+### Invoke
+
+Help me define requirements for a task management REST API.
+
+### What Feature Forge Provides
+
+- User stories  
+- Acceptance criteria  
+- Functional requirements  
+- Data model outline  
+
+### Example Output (Excerpt)
+
+    ### User Stories
+    1. As a user, I can create a task with a title and description.
+    2. As a user, I can retrieve all tasks.
+    3. As a user, I can mark a task as completed.
+    4. As a user, I can delete a task.
+
+    ### Acceptance Criteria
+    - API must return correct HTTP status codes.
+    - Input validation must be enforced.
+    - Errors must follow consistent JSON format.
+
+---
+
+## Step 2 — Design the API with API Designer
+
+### Invoke
+
+Design RESTful endpoints based on the defined task management requirements.
+
+### What API Designer Provides
+
+- Resource modeling
+- HTTP method mapping
+- OpenAPI schema outline
+- Error handling conventions
+
+### Example OpenAPI Snippet
+
+    paths:
+      /tasks:
+        get:
+          summary: Retrieve all tasks
+        post:
+          summary: Create a new task
+
+      /tasks/{id}:
+        patch:
+          summary: Update task status
+        delete:
+          summary: Delete a task
+
+---
+
+## Step 3 — Implement with FastAPI Expert
+
+### Invoke
+
+Generate FastAPI implementation using async SQLAlchemy.
+
+### What FastAPI Expert Provides
+
+- Pydantic models
+- Async route handlers
+- Dependency injection
+- Database integration
+
+### Example Implementation
+
+    @app.get("/tasks")
+    async def list_tasks(db: AsyncSession = Depends(get_db)):
+        result = await db.execute(select(Task))
+        return result.scalars().all()
+
+    @app.post("/tasks", status_code=201)
+    async def create_task(task: TaskCreate, db: AsyncSession = Depends(get_db)):
+        new_task = Task(**task.dict())
+        db.add(new_task)
+        await db.commit()
+        return new_task
+
+---
+
+## Step 4 — Validate with Test Master
+
+### Invoke
+
+Generate pytest test cases for the task API.
+
+### What Test Master Provides
+
+- Unit tests
+- Integration tests
+- Edge case validation
+- Mock database setup
+
+### Example Test Case
+
+    def test_create_task(client):
+        response = client.post("/tasks", json={"title": "Test Task"})
+        assert response.status_code == 201
+        assert response.json()["title"] == "Test Task"
+
+---
+
+## Step 5 — Prepare Deployment with DevOps Engineer
+
+### Invoke
+
+Generate Dockerfile and CI workflow for deployment.
+
+### What DevOps Engineer Provides
+
+- Production Dockerfile
+- Environment configuration
+- CI/CD setup
+- Security hardening suggestions
+
+### Example Dockerfile
+
+    FROM python:3.11-slim
+    WORKDIR /app
+    COPY . .
+    RUN pip install -r requirements.txt
+    CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+---
+
+## Skill Flow Summary
+
+1. Feature Forge defines structured requirements.
+2. API Designer converts requirements into REST architecture.
+3. FastAPI Expert implements production-ready code.
+4. Test Master ensures correctness and reliability.
+5. DevOps Engineer prepares the system for deployment.
+
+---
+
+## Key Takeaways
+
+- Skills are sequential and composable.
+- Structured requirements prevent chaotic implementation.
+- Testing and DevOps are first-class steps, not afterthoughts.
+- Multi-skill chaining improves quality and clarity.
+
+---
+
+## Final Result
+
+A fully tested, containerized REST API built using structured multi-skill collaboration.


### PR DESCRIPTION
Closes #98

Added examples/ directory with 3 real-world workflow walkthroughs demonstrating multi-skill usage.

Includes:
- REST_API_FROM_SCRATCH.md
- DEBUGGING_PRODUCTION_ISSUE.md
- ADDING_AUTHENTICATION.md
- examples/README.md

Each example demonstrates chaining 3+ skills with realistic invocation and outputs.

Also updated root README 
