### PR TITLE
Fix: remove incorrect Python/Pydantic reference in php-pro skill

### DIFF
--- a/skills/php-pro/SKILL.md
+++ b/skills/php-pro/SKILL.md
@@ -64,7 +64,6 @@ Load detailed guidance based on context:
 
 ### MUST NOT DO
 - Skip type declarations (no mixed types)
-- Use deprecated features or Pydantic V1 patterns
 - Store passwords in plain text (use bcrypt/argon2)
 - Write SQL queries vulnerable to injection
 - Mix business logic with controllers


### PR DESCRIPTION
Remove copy-paste error from php-pro SKILL.md.

The MUST NOT DO section contained "Use deprecated features or Pydantic V1 patterns",
which is a Python/FastAPI constraint with no relevance in a PHP context.

Fixes the accuracy of the skill guidelines.