### PR TITLE
Link to "docs" is not working in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Surface and validate Claude's hidden assumptions about your project with `/commo
 
 ## Project Workflow
 
-<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> workflow commands manage epics from discovery through retrospectives, integrating with Jira and Confluence. See [**Workflow Commands Reference**](docs/WORKFLOW_COMMANDS.md) for the full command reference and lifecycle diagrams.
+The <!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> workflow commands manage epics from discovery through retrospectives, integrating with Jira and Confluence. See [**Workflow Commands Reference**](docs/WORKFLOW_COMMANDS.md) for the full command reference and lifecycle diagrams.
 
 > [!TIP]
 > **Setup:** Workflow commands require an Atlassian MCP server. See the [**Atlassian MCP Setup Guide**](docs/ATLASSIAN_MCP_SETUP.md).


### PR DESCRIPTION
A small hack because the link to the workflow commands docs is not correctly rendered because the beginning of the line started with a comment sign. Hence I added the word "The" on the front.