### PR TITLE
Fix: add missing name field to retrospectives command frontmatter

### DIFF
--- a/commands/project/retrospectives/complete-epic.md
+++ b/commands/project/retrospectives/complete-epic.md
@@ -1,4 +1,5 @@
 ---
+name: complete-epic
 description: Complete an epic after all tickets are executed, generate report, and close in Jira
 argument-hint: <epic-key>
 ---

--- a/commands/project/retrospectives/complete-sprint.md
+++ b/commands/project/retrospectives/complete-sprint.md
@@ -1,4 +1,5 @@
 ---
+name: complete-sprint
 description: Generate comprehensive sprint retrospective from completed epics
 argument-hint: <sprint-number-or-folder-path>
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`commands/project/retrospectives/complete-sprint.md` and `commands/project/retrospectives/complete-epic.md` are missing the `name` field in their YAML frontmatter.

Without a `name` field, Claude Code cannot register these commands by name — they are treated as anonymous and cannot be invoked as `/complete-sprint` or `/complete-epic`.

## Fix

Added `name: complete-sprint` and `name: complete-epic` respectively, matching the filename-without-extension convention used by the rest of the plugin ecosystem and confirmed by the YAML config files alongside each command.

## Files changed

- `commands/project/retrospectives/complete-sprint.md` — added `name: complete-sprint`
- `commands/project/retrospectives/complete-epic.md` — added `name: complete-epic`