### PR TITLE
Fix: add missing name field to discovery command frontmatter

### DIFF
--- a/commands/project/discovery/approve-synthesis.md
+++ b/commands/project/discovery/approve-synthesis.md
@@ -1,4 +1,5 @@
 ---
+name: approve-synthesis
 description: Approve synthesis findings and create implementation tickets from discovery
 argument-hint: <synthesis-url> [--decision=<id>:<value>...]
 ---

--- a/commands/project/discovery/create-epic-discovery.md
+++ b/commands/project/discovery/create-epic-discovery.md
@@ -1,4 +1,5 @@
 ---
+name: create-epic-discovery
 description: Create a discovery document for research/customer discovery epics
 argument-hint: <epic-key>
 ---

--- a/commands/project/discovery/synthesize-discovery.md
+++ b/commands/project/discovery/synthesize-discovery.md
@@ -1,4 +1,5 @@
 ---
+name: synthesize-discovery
 description: Synthesize discovery findings into a consolidated analysis document with proposed tickets
 argument-hint: <source-url> [source-url...] [--target=<epic-key>]
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three discovery commands were missing the `name` field in their YAML frontmatter:

- `commands/project/discovery/create-epic-discovery.md`
- `commands/project/discovery/synthesize-discovery.md`
- `commands/project/discovery/approve-synthesis.md`

Without a `name` field, Claude Code cannot register these commands by name — they are treated as anonymous and cannot be invoked as `/create-epic-discovery`, `/synthesize-discovery`, or `/approve-synthesis`.

## Fix

Added `name` fields matching the filename-without-extension convention:
- `name: create-epic-discovery`
- `name: synthesize-discovery`
- `name: approve-synthesis`

## Files changed

- `commands/project/discovery/create-epic-discovery.md` — added `name: create-epic-discovery`
- `commands/project/discovery/synthesize-discovery.md` — added `name: synthesize-discovery`
- `commands/project/discovery/approve-synthesis.md` — added `name: approve-synthesis`