### PR TITLE
Fix: add missing name field to planning command frontmatter

### DIFF
--- a/commands/project/planning/create-epic-plan.md
+++ b/commands/project/planning/create-epic-plan.md
@@ -1,4 +1,5 @@
 ---
+name: create-epic-plan
 description: Create an epic planning document by analyzing Jira tickets and codebase
 argument-hint: <epic-key>
 ---

--- a/commands/project/planning/create-implementation-plan.md
+++ b/commands/project/planning/create-implementation-plan.md
@@ -1,4 +1,5 @@
 ---
+name: create-implementation-plan
 description: Generate an implementation plan from a planning document
 argument-hint: <overview-doc-url>
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two planning commands were missing the `name` field in their YAML frontmatter:

- `commands/project/planning/create-epic-plan.md`
- `commands/project/planning/create-implementation-plan.md`

Without a `name` field, Claude Code cannot register these commands by name — they are treated as anonymous and cannot be invoked as `/create-epic-plan` or `/create-implementation-plan`.

## Fix

Added `name` fields matching the filename-without-extension convention:
- `name: create-epic-plan`
- `name: create-implementation-plan`

## Files changed

- `commands/project/planning/create-epic-plan.md` — added `name: create-epic-plan`
- `commands/project/planning/create-implementation-plan.md` — added `name: create-implementation-plan`