### PR TITLE
Fix: add missing name field to execution command frontmatter

### DIFF
--- a/commands/project/execution/complete-ticket.md
+++ b/commands/project/execution/complete-ticket.md
@@ -1,4 +1,5 @@
 ---
+name: complete-ticket
 description: Complete a ticket after execution - transitions Jira to "In Review" and updates the implementation plan
 argument-hint: [ticket-key] (optional if context available)
 ---

--- a/commands/project/execution/execute-ticket.md
+++ b/commands/project/execution/execute-ticket.md
@@ -1,4 +1,5 @@
 ---
+name: execute-ticket
 description: Execute a Jira ticket following its implementation plan
 argument-hint: <ticket-key>
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two execution commands were missing the `name` field in their YAML frontmatter:

- `commands/project/execution/execute-ticket.md`
- `commands/project/execution/complete-ticket.md`

Without a `name` field, Claude Code cannot register these commands by name — they are treated as anonymous and cannot be invoked as `/execute-ticket` or `/complete-ticket`.

## Fix

Added `name` fields matching the filename-without-extension convention:
- `name: execute-ticket`
- `name: complete-ticket`

## Files changed

- `commands/project/execution/execute-ticket.md` — added `name: execute-ticket`
- `commands/project/execution/complete-ticket.md` — added `name: complete-ticket`