### PR TITLE
Fix: add missing name field to common-ground command frontmatter

### DIFF
--- a/commands/common-ground/COMMAND.md
+++ b/commands/common-ground/COMMAND.md
@@ -1,4 +1,5 @@
 ---
+name: common-ground
 description: Surface and validate Claude's hidden assumptions about the project for user confirmation
 argument-hint: "[--list] [--check] [--graph]"
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`commands/common-ground/COMMAND.md` is missing the `name` field in its YAML frontmatter.

Without a `name` field, Claude Code cannot register this command by name — it is treated as anonymous and cannot be invoked as `/common-ground`.

## Fix

Added `name: common-ground` to the frontmatter. This name is confirmed by the adjacent `common-ground.yaml` config file, which explicitly declares `command: "common-ground"` for this file.

## Files changed

- `commands/common-ground/COMMAND.md` — added `name: common-ground`