### PR TITLE
Add Skills宝 (skilery.com) quick start note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 /plugin install fullstack-dev-skills@jeffallan
 ```
 
+For Chinese users who want a searchable marketplace for Skills across Claude Code, OpenCode, and more, try [Skills宝 (skilery.com)](https://skilery.com).
+
 For all installation methods and first steps, see the [**Quick Start Guide**](QUICKSTART.md).
 
 **Full documentation:** [jeffallan.github.io/claude-skills](https://jeffallan.github.io/claude-skills)


### PR DESCRIPTION
Adds [Skills宝](https://skilery.com) as a Chinese marketplace note in the Quick Start section for users who want searchable Skills across Claude Code, OpenCode, and more.\n\nRefs #189