### PR TITLE
Add: 16 reference files and expanded SKILL.md routing for laravel-specialist

### DIFF
--- a/skills/laravel-specialist/SKILL.md
+++ b/skills/laravel-specialist/SKILL.md
@@ -15,167 +15,83 @@ metadata:
 
 # Laravel Specialist
 
-Senior Laravel specialist with deep expertise in Laravel 10+, Eloquent ORM, and modern PHP 8.2+ development.
+Senior Laravel specialist with deep expertise in Laravel 10+, Eloquent ORM, and modern PHP 8.2+.
 
 ## Core Workflow
 
-1. **Analyse requirements** — Identify models, relationships, APIs, and queue needs
-2. **Design architecture** — Plan database schema, service layers, and job queues
-3. **Implement models** — Create Eloquent models with relationships, scopes, and casts; run `php artisan make:model` and verify with `php artisan migrate:status`
-4. **Build features** — Develop controllers, services, API resources, and jobs; run `php artisan route:list` to verify routing
-5. **Test thoroughly** — Write feature and unit tests; run `php artisan test` before considering any step complete (target >85% coverage)
+1. **Analyse** — Identify models, relationships, APIs, queue needs
+2. **Design** — Plan schema, service layers, job queues
+3. **Implement** — Create models, migrations; verify with `php artisan migrate:status`
+4. **Build** — Controllers, services, API resources, jobs; verify with `php artisan route:list`
+5. **Test** — Write tests; run `php artisan test` (>85% coverage target)
 
 ## Reference Guide
 
-Load detailed guidance based on context:
-
 | Topic | Reference | Load When |
 |-------|-----------|-----------|
-| Eloquent ORM | `references/eloquent.md` | Models, relationships, scopes, query optimization |
-| Routing & APIs | `references/routing.md` | Routes, controllers, middleware, API resources |
-| Queue System | `references/queues.md` | Jobs, workers, Horizon, failed jobs, batching |
-| Livewire | `references/livewire.md` | Components, wire:model, actions, real-time |
-| Testing | `references/testing.md` | Feature tests, factories, mocking, Pest PHP |
-| Blade & View Components | `references/view-components.md` | Blade templates, components, slots, composers |
-| Events & Listeners | `references/events.md` | Events, listeners, queued listeners, subscribers, event testing |
-| Sanctum / Auth | `references/sanctum.md` | API tokens, SPA auth, token abilities, mobile auth |
-| Validation | `references/validation.md` | Form requests, rules, custom validation, error messages |
-| Authorization | `references/authorization.md` | Gates, policies, `@can`, middleware authorization |
-| Notifications | `references/notifications.md` | Mail, database, broadcast, Slack, SMS, on-demand |
-| Broadcasting | `references/broadcasting.md` | WebSockets, Echo, Reverb, Pusher, Ably, channels |
-| Service Container | `references/container.md` | Binding, resolution, contextual attributes, `#[Singleton]` |
-| Artisan Console | `references/artisan.md` | Custom commands, I/O, scheduling, signals |
-| Collections | `references/collections.md` | `collect()`, filtering, mapping, sorting, reducing, lazy collections |
-| Helpers | `references/helpers.md` | `Arr`, `Str`, `Number`, URLs, `dispatch()`, `throw_if()` |
+| Eloquent ORM | `references/eloquent.md` | Models, relationships, scopes, queries |
+| Routing & APIs | `references/routing.md` | Routes, controllers, middleware, resources |
+| Queue System | `references/queues.md` | Jobs, workers, Horizon, batching |
+| Livewire | `references/livewire.md` | Components, wire:model, real-time |
+| Testing | `references/testing.md` | Feature tests, factories, Pest PHP |
+| Blade & Views | `references/view-components.md` | Blade templates, components, slots |
+| Events | `references/events.md` | Events, listeners, subscribers |
+| Sanctum / Auth | `references/sanctum.md` | API tokens, SPA auth, abilities |
+| Validation | `references/validation.md` | Form requests, rules, custom validation |
+| Authorization | `references/authorization.md` | Gates, policies, `@can` |
+| Notifications | `references/notifications.md` | Mail, database, broadcast, Slack |
+| Broadcasting | `references/broadcasting.md` | WebSockets, Echo, Reverb, Pusher |
+| Service Container | `references/container.md` | Bindings, resolution, `#[Singleton]` |
+| Artisan Console | `references/artisan.md` | Custom commands, scheduling |
+| Collections | `references/collections.md` | `collect()`, filtering, lazy collections |
+| Helpers | `references/helpers.md` | `Arr`, `Str`, `Number`, URLs |
 
 ## Constraints
 
 ### MUST DO
-- Use PHP 8.2+ features (readonly, enums, typed properties)
-- Type hint all method parameters and return types
-- Use Eloquent relationships properly (avoid N+1 with eager loading)
-- Implement API resources for transforming data
+- PHP 8.2+ features (readonly, enums, typed properties)
+- Type hint all parameters and return types
+- Eager-load relationships (avoid N+1)
+- API resources for data transformation
 - Queue long-running tasks
-- Write comprehensive tests (>85% coverage)
-- Use service containers and dependency injection
-- Follow PSR-12 coding standards
+- Tests >85% coverage, PSR-12 standards
+- Use service containers and DI
 
 ### MUST NOT DO
-- Use raw queries without protection (SQL injection)
-- Skip eager loading (causes N+1 problems)
+- Raw queries without protection (SQL injection)
+- Skip eager loading (N+1 problems)
 - Store sensitive data unencrypted
 - Mix business logic in controllers
 - Hardcode configuration values
 - Skip validation on user input
 - Use deprecated Laravel features
-- Ignore queue failures
 
 ## Code Templates
-
-Use these as starting points for every implementation.
 
 ### Eloquent Model
 
 ```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
-
 final class Post extends Model
 {
     use HasFactory, SoftDeletes;
-
     protected $fillable = ['title', 'body', 'status', 'user_id'];
-
-    protected $casts = [
-        'status' => PostStatus::class, // backed enum
-        'published_at' => 'immutable_datetime',
-    ];
-
-    // Relationships — always eager-load via ::with() at call site
-    public function author(): BelongsTo
-    {
-        return $this->belongsTo(User::class, 'user_id');
-    }
-
-    public function comments(): HasMany
-    {
-        return $this->hasMany(Comment::class);
-    }
-
-    // Local scope
-    public function scopePublished(Builder $query): Builder
-    {
-        return $query->where('status', PostStatus::Published);
-    }
+    protected $casts = ['status' => PostStatus::class, 'published_at' => 'immutable_datetime'];
+    public function author(): BelongsTo { return $this->belongsTo(User::class); }
+    public function comments(): HasMany { return $this->hasMany(Comment::class); }
+    public function scopePublished(Builder $query): Builder { return $query->where('status', PostStatus::Published); }
 }
-```
-
-### Migration
-
-```php
-<?php
-
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
-
-return new class extends Migration
-{
-    public function up(): void
-    {
-        Schema::create('posts', function (Blueprint $table): void {
-            $table->id();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->string('title');
-            $table->text('body');
-            $table->string('status')->default('draft');
-            $table->timestamp('published_at')->nullable();
-            $table->softDeletes();
-            $table->timestamps();
-        });
-    }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('posts');
-    }
-};
 ```
 
 ### API Resource
 
 ```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Http\Resources;
-
-use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\JsonResource;
-
 final class PostResource extends JsonResource
 {
     public function toArray(Request $request): array
     {
-        return [
-            'id'           => $this->id,
-            'title'        => $this->title,
-            'body'         => $this->body,
-            'status'       => $this->status->value,
-            'published_at' => $this->published_at?->toIso8601String(),
-            'author'       => new UserResource($this->whenLoaded('author')),
-            'comments'     => CommentResource::collection($this->whenLoaded('comments')),
-        ];
+        return ['id' => $this->id, 'title' => $this->title, 'body' => $this->body,
+            'status' => $this->status->value, 'published_at' => $this->published_at?->toIso8601String(),
+            'author' => new UserResource($this->whenLoaded('author'))];
     }
 }
 ```
@@ -183,164 +99,39 @@ final class PostResource extends JsonResource
 ### Queued Job
 
 ```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Jobs;
-
-use App\Models\Post;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-
 final class PublishPost implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     public int $tries = 3;
-    public int $backoff = 60;
-
-    public function __construct(
-        private readonly Post $post,
-    ) {}
-
-    public function handle(): void
-    {
-        $this->post->update([
-            'status'       => PostStatus::Published,
-            'published_at' => now(),
-        ]);
-    }
-
-    public function failed(\Throwable $e): void
-    {
-        // Log or notify — never silently swallow failures
-        logger()->error('PublishPost failed', ['post' => $this->post->id, 'error' => $e->getMessage()]);
-    }
+    public function __construct(private readonly Post $post) {}
+    public function handle(): void { $this->post->update(['status' => PostStatus::Published, 'published_at' => now()]); }
+    public function failed(\Throwable $e): void { logger()->error('PublishPost failed', ['error' => $e->getMessage()]); }
 }
 ```
 
 ### Feature Test (Pest)
 
 ```php
-<?php
-
-use App\Models\Post;
-use App\Models\User;
-
-it('returns a published post for authenticated users', function (): void {
+it('returns a published post', function (): void {
     $user = User::factory()->create();
     $post = Post::factory()->published()->for($user, 'author')->create();
-
-    $response = $this->actingAs($user)
-        ->getJson("/api/posts/{$post->id}");
-
-    $response->assertOk()
-        ->assertJsonPath('data.status', 'published')
-        ->assertJsonPath('data.author.id', $user->id);
+    $this->actingAs($user)->getJson("/api/posts/{$post->id}")
+        ->assertOk()->assertJsonPath('data.status', 'published');
 });
-
-it('queues a publish job when a draft is submitted', function (): void {
-    Queue::fake();
-    $user = User::factory()->create();
-    $post = Post::factory()->draft()->for($user, 'author')->create();
-
-    $this->actingAs($user)
-        ->postJson("/api/posts/{$post->id}/publish")
-        ->assertAccepted();
-
-    Queue::assertPushed(PublishPost::class, fn ($job) => $job->post->is($post));
-});
-```
-
-### Blade Component
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\View\Components;
-
-use Illuminate\View\Component;
-use Illuminate\View\View;
-
-final class Alert extends Component
-{
-    public function __construct(
-        public string $type = 'info',
-        public string $message = '',
-    ) {}
-
-    public function render(): View
-    {
-        return view('components.alert');
-    }
-}
-```
-
-```blade
-{{-- resources/views/components/alert.blade.php --}}
-@props(['type' => 'info', 'message' => ''])
-
-<div class="alert alert-{{ $type }}" {{ $attributes }}>
-    {{ $message }}
-    {{ $slot }}
-</div>
-```
-
-### View Composer
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\View\Composers;
-
-use App\Repositories\UserRepository;
-use Illuminate\View\View;
-
-final class ProfileComposer
-{
-    public function __construct(
-        private readonly UserRepository $users,
-    ) {}
-
-    public function compose(View $view): void
-    {
-        $view->with('count', $this->users->count());
-    }
-}
-```
-
-```php
-// Register in AppServiceProvider
-use Illuminate\Support\Facades\View;
-
-public function boot(): void
-{
-    View::composer('profile', ProfileComposer::class);
-}
 ```
 
 ## Validation Checkpoints
 
-Run these at each workflow stage to confirm correctness before proceeding:
-
-| Stage | Command | Expected Result |
-|-------|---------|-----------------|
-| After migration | `php artisan migrate:status` | All migrations show `Ran` |
-| After routing | `php artisan route:list --path=api` | New routes appear with correct verbs |
-| After job dispatch | `php artisan queue:work --once` | Job processes without exception |
-| After implementation | `php artisan test --coverage` | >85% coverage, 0 failures |
-| Before PR | `./vendor/bin/pint --test` | PSR-12 linting passes |
+| Stage | Command | Expected |
+|-------|---------|----------|
+| Migration | `php artisan migrate:status` | All `Ran` |
+| Routing | `php artisan route:list --path=api` | Routes with correct verbs |
+| Queue | `php artisan queue:work --once` | No exception |
+| Test | `php artisan test --coverage` | >85%, 0 failures |
+| Lint | `./vendor/bin/pint --test` | PSR-12 passes |
 
 ## Knowledge Reference
 
-Laravel 10+, Eloquent ORM, PHP 8.2+, API resources, Sanctum/Passport, queues, Horizon, Livewire, Inertia, Octane, Pest/PHPUnit, Redis, broadcasting, events/listeners, notifications, task scheduling
+Laravel 10+, Eloquent ORM, PHP 8.2+, API resources, Sanctum, queues, Horizon, Livewire, Inertia, Octane, Pest/PHPUnit, Redis, broadcasting, events, notifications, scheduling
 
 [Documentation](https://jeffallan.github.io/claude-skills/skills/backend/laravel-specialist/)

--- a/skills/laravel-specialist/SKILL.md
+++ b/skills/laravel-specialist/SKILL.md
@@ -4,7 +4,7 @@ description: Build and configure Laravel 10+ applications, including creating El
 license: MIT
 metadata:
   author: https://github.com/Jeffallan
-  version: "1.1.0"
+  version: "1.2.0"
   domain: backend
   triggers: Laravel, Eloquent, PHP framework, Laravel API, Artisan, Blade templates, Laravel queues, Livewire, Laravel testing, Sanctum, Horizon
   role: specialist
@@ -36,6 +36,17 @@ Load detailed guidance based on context:
 | Queue System | `references/queues.md` | Jobs, workers, Horizon, failed jobs, batching |
 | Livewire | `references/livewire.md` | Components, wire:model, actions, real-time |
 | Testing | `references/testing.md` | Feature tests, factories, mocking, Pest PHP |
+| Blade & View Components | `references/view-components.md` | Blade templates, components, slots, composers |
+| Events & Listeners | `references/events.md` | Events, listeners, queued listeners, subscribers, event testing |
+| Sanctum / Auth | `references/sanctum.md` | API tokens, SPA auth, token abilities, mobile auth |
+| Validation | `references/validation.md` | Form requests, rules, custom validation, error messages |
+| Authorization | `references/authorization.md` | Gates, policies, `@can`, middleware authorization |
+| Notifications | `references/notifications.md` | Mail, database, broadcast, Slack, SMS, on-demand |
+| Broadcasting | `references/broadcasting.md` | WebSockets, Echo, Reverb, Pusher, Ably, channels |
+| Service Container | `references/container.md` | Binding, resolution, contextual attributes, `#[Singleton]` |
+| Artisan Console | `references/artisan.md` | Custom commands, I/O, scheduling, signals |
+| Collections | `references/collections.md` | `collect()`, filtering, mapping, sorting, reducing, lazy collections |
+| Helpers | `references/helpers.md` | `Arr`, `Str`, `Number`, URLs, `dispatch()`, `throw_if()` |
 
 ## Constraints
 
@@ -243,6 +254,77 @@ it('queues a publish job when a draft is submitted', function (): void {
 
     Queue::assertPushed(PublishPost::class, fn ($job) => $job->post->is($post));
 });
+```
+
+### Blade Component
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+final class Alert extends Component
+{
+    public function __construct(
+        public string $type = 'info',
+        public string $message = '',
+    ) {}
+
+    public function render(): View
+    {
+        return view('components.alert');
+    }
+}
+```
+
+```blade
+{{-- resources/views/components/alert.blade.php --}}
+@props(['type' => 'info', 'message' => ''])
+
+<div class="alert alert-{{ $type }}" {{ $attributes }}>
+    {{ $message }}
+    {{ $slot }}
+</div>
+```
+
+### View Composer
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\View\Composers;
+
+use App\Repositories\UserRepository;
+use Illuminate\View\View;
+
+final class ProfileComposer
+{
+    public function __construct(
+        private readonly UserRepository $users,
+    ) {}
+
+    public function compose(View $view): void
+    {
+        $view->with('count', $this->users->count());
+    }
+}
+```
+
+```php
+// Register in AppServiceProvider
+use Illuminate\Support\Facades\View;
+
+public function boot(): void
+{
+    View::composer('profile', ProfileComposer::class);
+}
 ```
 
 ## Validation Checkpoints

--- a/skills/laravel-specialist/references/artisan.md
+++ b/skills/laravel-specialist/references/artisan.md
@@ -1,0 +1,509 @@
+# Artisan Console
+
+## Tinker (REPL)
+
+```shell
+# Start an interactive PHP REPL with the application booted
+php artisan tinker
+
+> User::count()
+=> 42
+> User::where('email', 'john@example.com')->first()
+=> App\Models\User {#...}
+> $user = User::factory()->create()
+=> App\Models\User {#...}
+> $user->posts()->create(['title' => 'Hello'])
+=> App\Models\Post {#...}
+```
+
+Configure the allow list for classes that can be instantiated in `config/tinker.php`:
+
+```php
+'alias' => [
+    'User' => App\Models\User::class,
+],
+
+'dont_alias' => [
+    App\Models\Payment::class,
+],
+```
+
+## Writing Commands
+
+```shell
+php artisan make:command SendEmails
+```
+
+### Command Structure (PHP 8 Attributes)
+
+```php
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Support\DripEmailer;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('mail:send {user}')]
+#[Description('Send a marketing email to a user')]
+class SendEmails extends Command
+{
+    public function handle(DripEmailer $drip): void
+    {
+        $drip->send(User::findOrFail($this->argument('user')));
+    }
+}
+```
+
+### Exit Codes
+
+```php
+use Illuminate\Console\Command;
+
+class SendEmails extends Command
+{
+    #[Signature('mail:send {user}')]
+    #[Description('Send a marketing email to a user')]
+    public function handle(): int
+    {
+        $user = User::find($this->argument('user'));
+
+        if (! $user) {
+            $this->error('User not found');
+
+            return Command::FAILURE;
+        }
+
+        // ...
+
+        return Command::SUCCESS;
+    }
+
+    // Also available: Command::INVALID
+}
+```
+
+### Failing Commands
+
+```php
+public function handle(): void
+{
+    $this->fail('Something went wrong');
+    // Automatically exits with FAILURE
+}
+```
+
+## Closure Commands
+
+Define lightweight commands in `routes/console.php`:
+
+```php
+use Illuminate\Support\Facades\Artisan;
+
+Artisan::command('mail:send {user}', function (string $user) {
+    $this->info("Sending email to: {$user}!");
+})->purpose('Send a marketing email to a user');
+```
+
+The closure is bound to the command instance, giving access to `$this->info()`, `$this->argument()`, etc.
+
+### Scheduling Closure Commands
+
+```php
+Artisan::command('delete:recent-users', function () {
+    DB::table('recent_users')->delete();
+})->purpose('Delete recent users')->daily();
+```
+
+## Isolatable Commands
+
+Prevent overlapping execution:
+
+```php
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Isolatable;
+
+class SendEmails extends Command implements Isolatable
+{
+    #[Signature('mail:send {user}')]
+    #[Description('Send a marketing email to a user')]
+    public function handle(): void
+    {
+        // Only one instance runs at a time
+    }
+}
+```
+
+No changes needed in `handle()`. The framework automatically acquires a lock.
+
+### Custom Isolation Key
+
+```php
+public function isolatableId(): string
+{
+    return $this->argument('user');
+}
+```
+
+### Custom Lock Expiration
+
+```php
+use Carbon\CarbonInterval;
+
+public function isolationLockExpiresAt(): CarbonInterval
+{
+    return CarbonInterval::minutes(5);
+}
+```
+
+### Manual Lock Bypass
+
+```shell
+php artisan mail:send 1 --isolated
+php artisan mail:send 1 --no-isolated
+```
+
+## Defining Input
+
+### Arguments
+
+```php
+// Required argument
+#[Signature('mail:send {user}')]
+
+// Optional argument
+#[Signature('mail:send {user?}')]
+
+// Default value
+#[Signature('mail:send {user=foo}')]
+
+// Array argument
+#[Signature('mail:send {users*}')]
+```
+
+### Options
+
+```php
+// Switch (boolean)
+#[Signature('mail:send {--queue}')]
+
+// With value (required)
+#[Signature('mail:send {--queue=}')]
+
+// With default
+#[Signature('mail:send {--queue=default}')]
+
+// Array option
+#[Signature('mail:send {--id=*}')]
+
+// Shortcut
+#[Signature('mail:send {-Q}')]
+```
+
+### Input Descriptions
+
+```php
+#[Signature('
+    mail:send
+    {user : The ID of the user to send to}
+    {--queue : Whether the job should be queued}
+')]
+```
+
+## Prompting for Missing Input
+
+Implement `PromptsForMissingInput` to automatically prompt users for missing required arguments:
+
+```php
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+
+class SendEmails extends Command implements PromptsForMissingInput
+{
+    #[Signature('mail:send {user}')]
+    #[Description('Send a marketing email to a user')]
+
+    public function handle(): void
+    {
+        $user = User::findOrFail($this->argument('user'));
+
+        // If called without user argument, prompts will ask for it
+    }
+}
+```
+
+## Command I/O
+
+### Retrieving Input
+
+```php
+public function handle(): void
+{
+    // Arguments
+    $userId = $this->argument('user');
+    $allArguments = $this->arguments();
+
+    // Options
+    $shouldQueue = $this->option('queue');
+    $allOptions = $this->options();
+
+    // Check presence
+    if ($this->hasArgument('user')) { /* ... */ }
+    if ($this->option('queue')) { /* ... */ }
+
+    // All arguments and options
+    $input = $this->input->getArguments();
+    $options = $this->input->getOptions();
+}
+```
+
+### Prompting
+
+```php
+// Text input
+$name = $this->ask('What is your name?');
+
+// Secret input (hidden)
+$password = $this->secret('What is the password?');
+
+// Confirmation
+if ($this->confirm('Do you wish to continue?', true)) {
+    // User said yes
+}
+
+// Autocomplete / Anticipate
+$name = $this->anticipate('What is your name?', ['John', 'Jane', 'Joe']);
+
+// Choice with options
+$role = $this->choice(
+    'What role should the user have?',
+    ['Admin', 'Editor', 'Subscriber'],
+    default: 0,
+    maxAttempts: 3,
+    multiple: false,
+);
+
+// Choice with multiple selections
+$permissions = $this->choice(
+    'Select permissions',
+    ['read', 'write', 'delete'],
+    multiple: true,
+);
+
+// Table with search
+$user = $this->choice(
+    'Select a user',
+    User::pluck('name', 'id')->toArray(),
+    searchable: true,
+);
+```
+
+### Writing Output
+
+```php
+// Status levels
+$this->info('Operation successful');
+$this->error('Something went wrong');
+$this->warn('Be careful');
+$this->line('Plain message');
+$this->newLine(2); // Multiple blank lines
+
+// Raw output (no formatting)
+$this->output->write('Inline text');
+
+// Tables
+$headers = ['Name', 'Email'];
+$rows = User::all(['name', 'email'])->toArray();
+$this->table($headers, $rows);
+
+// Progress bars
+$users = User::where('subscribed', true)->get();
+$bar = $this->output->createProgressBar($users->count());
+
+foreach ($users as $user) {
+    // Process user
+    $bar->advance();
+}
+
+$bar->finish();
+$this->newLine(2);
+
+// Progress bar with custom message
+$bar = $this->output->createProgressBar($users->count());
+$bar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %message%');
+$bar->setMessage('Processing...');
+$bar->start();
+
+// Task indicator
+$this->task('Processing users', function () {
+    return User::where('subscribed', true)->update(['processed' => true]);
+});
+// Output: "Processing users: ✔" or "Processing users: ✖"
+
+// Alert box
+$this->alert('Important operation starting');
+
+// Bullet list
+$this->bulletList([
+    'Item 1: description',
+    'Item 2: description',
+]);
+```
+
+### Components (More Structured Output)
+
+```php
+$this->components->info('Building application...');
+$this->components->task('Compiling assets', fn () => true);
+$this->components->warn('This is a warning');
+$this->components->twoColumnDetail('Key', 'Value');
+$this->components->bulletList(['First', 'Second']);
+```
+
+## Registering Commands
+
+In Laravel 11+, commands in `app/Console/Commands/` are auto-discovered. For manual registration in `bootstrap/app.php`:
+
+```php
+use Illuminate\Foundation\Application;
+use Illuminate\Console\Scheduling\Schedule;
+
+->withCommands([
+    __DIR__ . '/../app/Console/Commands',
+    App\Console\Commands\SendEmails::class,
+])
+```
+
+## Programmatically Executing Commands
+
+```php
+use Illuminate\Support\Facades\Artisan;
+
+// Execute and get exit code
+$exitCode = Artisan::call('mail:send', [
+    'user' => 1,
+    '--queue' => true,
+]);
+
+// Queue command for background execution
+Artisan::queue('mail:send', ['user' => 1])
+    ->onConnection('redis')
+    ->onQueue('commands')
+    ->delay(now()->addMinutes(10));
+
+// Pass options
+Artisan::call('mail:send', [
+    'user' => 1,
+    '--queue' => 'high',
+]);
+```
+
+### Calling Commands From Other Commands
+
+```php
+public function handle(): void
+{
+    $this->call('mail:send', [
+        'user' => 1,
+    ]);
+
+    // Silently (suppresses output)
+    $this->callSilently('mail:send', ['user' => 1]);
+
+    // Capture output
+    $output = $this->output->capture(function () {
+        $this->call('mail:send', ['user' => 1]);
+    });
+}
+```
+
+## Signal Handling
+
+Trap OS signals within a command:
+
+```php
+public function handle(): void
+{
+    $this->trap(SIGTERM, function () {
+        $this->info('Shutting down gracefully...');
+        // Cleanup resources
+        exit(0);
+    });
+
+    $this->trap(SIGINT, function () {
+        $this->warn('Interrupted by user');
+        exit(1);
+    });
+
+    // Long-running process
+    while (true) {
+        // Process
+    }
+}
+```
+
+## Stub Customization
+
+Publish stubs to `stubs/` directory for customization:
+
+```shell
+php artisan stub:publish
+```
+
+Customize generated files by modifying stubs:
+
+```
+stubs/
+├── console.stub          # php artisan make:command
+├── controller.api.stub   # php artisan make:controller --api
+├── controller.model.stub # php artisan make:controller --model
+├── controller.stub       # php artisan make:controller
+├── event.stub
+├── job.stub
+├── model.stub
+├── notification.stub
+├── etc.
+```
+
+## Testing Commands
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+test('command sends email', function () {
+    $user = User::factory()->create();
+
+    $this->artisan('mail:send', ['user' => $user->id])
+        ->expectsQuestion('What is your name?', 'Taylor Otwell')
+        ->expectsChoice('Which language?', 'PHP', ['PHP', 'Ruby'])
+        ->expectsOutput('Email sent successfully')
+        ->doesntExpectOutput('Error')
+        ->assertExitCode(0);
+});
+```
+
+## Best Practices
+
+1. **Keep commands thin** — delegate business logic to services and actions
+2. **Use `#[Signature]` and `#[Description]` attributes** — cleaner than `$signature` and `$description` properties
+3. **Use `PromptsForMissingInput`** — improves UX by automatically prompting for required arguments
+4. **Implement `Isolatable` for scheduled commands** — prevents overlaps
+5. **Use `$this->components->task()` for reporting progress** — cleaner than manual progress bar management
+6. **Return `Command::SUCCESS` or `Command::FAILURE`** — enables composability in pipelines
+7. **Use `Artisan::queue()` for heavy commands** — avoid blocking the HTTP request
+8. **Handle signals in long-running commands** — `$this->trap()` for graceful shutdown
+9. **Use `$this->call()` to compose complex workflows** — chain multiple commands together
+10. **Test command I/O** — use `expectsQuestion()`, `expectsOutput()`, and `assertExitCode()` in tests

--- a/skills/laravel-specialist/references/authorization.md
+++ b/skills/laravel-specialist/references/authorization.md
@@ -1,0 +1,512 @@
+# Authorization
+
+## Gates
+
+### Defining Gates
+
+```php
+<?php
+
+namespace App\Providers;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Gate::define('update-post', function (User $user, Post $post) {
+            return $user->id === $post->user_id;
+        });
+
+        Gate::define('delete-post', function (User $user, Post $post) {
+            return $user->id === $post->user_id;
+        });
+
+        Gate::define('publish-post', function (User $user, Post $post) {
+            return $user->isAdmin() || $user->id === $post->user_id;
+        });
+    }
+}
+```
+
+### Authorizing via Gates
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Gate;
+
+// Basic checks
+if (Gate::allows('update-post', $post)) {
+    // User can update
+}
+
+if (Gate::denies('update-post', $post)) {
+    // User cannot update
+}
+
+// Authorize or abort
+Gate::authorize('update-post', $post);
+
+// Inspect returns a response object
+$response = Gate::inspect('update-post', $post);
+
+if ($response->allowed()) {
+    // Action allowed
+} else {
+    echo $response->message();
+}
+```
+
+### Gate Responses
+
+```php
+<?php
+
+namespace App\Providers;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Gate::define('update-post', function (User $user, Post $post) {
+            return $user->id === $post->user_id
+                ? Response::allow()
+                : Response::deny('You do not own this post.');
+        });
+
+        Gate::define('view-report', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyWithStatus(403);
+        });
+
+        Gate::define('view-financials', function (User $user) {
+            return $user->isAdmin()
+                ? Response::allow()
+                : Response::denyAsNotFound();
+        });
+    }
+}
+```
+
+### Before / After Interception
+
+```php
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        // Before checks run before all other gate checks
+        Gate::before(function (User $user, string $ability) {
+            if ($user->isSuperAdmin()) {
+                return true;
+            }
+        });
+
+        // After checks run after all other gate checks
+        Gate::after(function (User $user, string $ability, ?bool $result, mixed $arguments) {
+            if ($user->isAdmin() && $ability === 'delete-post') {
+                return true;
+            }
+        });
+    }
+}
+```
+
+### Inline Authorization
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Gate;
+
+Gate::allowIf(fn (User $user) => $user->isAdmin());
+
+Gate::denyIf(fn (User $user) => $user->isBanned());
+```
+
+## Policies
+
+### Generating Policies
+
+```bash
+php artisan make:policy PostPolicy
+php artisan make:policy PostPolicy --model=Post
+```
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Post $post): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    public function update(User $user, Post $post): bool
+    {
+        return $user->id === $post->user_id;
+    }
+
+    public function delete(User $user, Post $post): bool
+    {
+        return $this->update($user, $post);
+    }
+
+    public function restore(User $user, Post $post): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function forceDelete(User $user, Post $post): bool
+    {
+        return $user->isAdmin();
+    }
+}
+```
+
+### Policy Auto-Discovery
+
+Laravel automatically discovers policies when the model and policy follow naming conventions (`Post` => `PostPolicy`). Manual registration is only needed for custom model/policy names:
+
+```php
+<?php
+
+namespace App\Providers;
+
+use App\Models\Post;
+use App\Policies\PostPolicy;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Gate::policy(Post::class, PostPolicy::class);
+    }
+}
+```
+
+### `#[UsePolicy]` Attribute
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Policies\PostPolicy;
+use Illuminate\Routing\Controller;
+use Illuminate\Foundation\Auth\Access\Attributes\UsePolicy;
+
+#[UsePolicy(PostPolicy::class)]
+class PostController extends Controller
+{
+    // Controller actions automatically authorize against PostPolicy
+}
+```
+
+### Policy Methods Without Models
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class PostPolicy
+{
+    public function create(User $user): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    // Guest users (not logged in)
+    public function view(?User $user, Post $post): bool
+    {
+        if ($post->isPublished()) {
+            return true;
+        }
+
+        return $user?->id === $post->user_id;
+    }
+}
+```
+
+### Policy Responses
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class PostPolicy
+{
+    public function update(User $user, Post $post): Response
+    {
+        return $user->id === $post->user_id
+            ? Response::allow()
+            : Response::deny('You do not own this post.');
+    }
+
+    public function archive(User $user, Post $post): Response
+    {
+        return $user->isAdmin()
+            ? Response::allow()
+            : Response::denyWithStatus(403);
+    }
+
+    public function viewDeleted(User $user): Response
+    {
+        return $user->isAdmin()
+            ? Response::allow()
+            : Response::denyAsNotFound();
+    }
+}
+```
+
+### Policy Filters
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class PostPolicy
+{
+    public function before(User $user, string $ability): ?bool
+    {
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        return null; // Let the method decide
+    }
+}
+```
+
+## Authorizing via User Model
+
+```php
+<?php
+
+if ($user->can('update', $post)) {
+    // User can update
+}
+
+if ($user->cannot('update', $post)) {
+    // User cannot update
+}
+
+// Authorize or abort
+$user->can('create', Post::class);
+```
+
+## Authorizing via Gate Facade
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Gate;
+
+// Using the gate facade to authorize
+Gate::authorize('update-post', $post);
+
+// Using for a specific user
+if (Gate::forUser($otherUser)->allows('update-post', $post)) {
+    // $otherUser can update
+}
+```
+
+## Authorizing via Middleware
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+// Using the can middleware
+Route::put('/posts/{post}', function (Post $post) {
+    // User must be authorized to update the post
+})->middleware('can:update,post');
+
+// With model binding
+Route::delete('/posts/{post}', function (Post $post) {
+    // User must be authorized to delete
+})->middleware('can:delete,post');
+
+// For create actions (no model instance)
+Route::post('/posts', function () {
+    // User must be authorized to create
+})->middleware('can:create,App\Models\Post');
+
+// Multiple abilities
+Route::get('/reports', function () {
+    // User must have at least one ability
+})->middleware('can:view-reports|export-reports');
+```
+
+## Authorizing via Blade
+
+```blade
+@can('update', $post)
+    <a href="{{ route('posts.edit', $post) }}">Edit</a>
+@endcan
+
+@cannot('update', $post)
+    <span>You cannot edit this post.</span>
+@endcannot
+
+@canany(['update', 'delete'], $post)
+    <div class="actions">
+        @can('update', $post)
+            <button>Edit</button>
+        @endcan
+        @can('delete', $post)
+            <button>Delete</button>
+        @endcan
+    </div>
+@endcanany
+
+@can('create', App\Models\Post::class)
+    <a href="{{ route('posts.create') }}">New Post</a>
+@endcan
+```
+
+## Authorization & Inertia
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+use Inertia\Middleware;
+
+class HandleInertiaRequests extends Middleware
+{
+    public function share(Request $request): array
+    {
+        return [
+            ...parent::share($request),
+            'auth' => [
+                'user' => $request->user(),
+                'permissions' => [
+                    'canCreatePosts' => $request->user()?->can('create', Post::class),
+                    'canManageUsers' => $request->user()?->can('manage-users'),
+                ],
+            ],
+        ];
+    }
+}
+```
+
+```vue
+<template>
+    <button v-if="$page.props.auth.permissions.canCreatePosts">
+        New Post
+    </button>
+</template>
+```
+
+## Supplying Additional Context
+
+```php
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+
+class PostPolicy
+{
+    public function forceDelete(User $user, Post $post, bool $hardDelete = false): bool
+    {
+        if ($hardDelete && $user->isSuperAdmin()) {
+            return true;
+        }
+
+        return false;
+    }
+}
+```
+
+Passing extra parameters:
+
+```php
+<?php
+
+use App\Models\Post;
+
+$user->can('forceDelete', [$post, true]);
+
+Gate::authorize('forceDelete', [$post, true]);
+
+// In blade
+@can('forceDelete', [$post, true])
+    // Show permanent delete button
+@endcan
+
+// In middleware (use array syntax)
+Route::delete('/posts/{post}/force', function (Post $post) {
+    //
+})->middleware('can:forceDelete,post,true');
+```
+
+## Best Practices
+
+1. **Prefer policies over gates** - Policies keep authorization organized per model
+2. **Use `#[UsePolicy]` on controllers** - Cleaner than authorizing manually in each method
+3. **Return `Response::denyWithStatus()`** - Return proper HTTP status codes for API endpoints
+4. **Use `before()` sparingly** - Only for super-admin shortcuts; let individual methods decide
+5. **Handle guest users explicitly** - Type-hint `?User` for abilities guests can access
+6. **Authorize at the route level** - Use `can` middleware for cleaner controller logic
+7. **Share permissions for SPAs** - Precompute permissions for Inertia or Vue frontends
+8. **Use `denyAsNotFound()`** - Hide sensitive resources from unauthorized users
+9. **Keep policies single-responsibility** - One policy per model; use gates for non-model actions
+10. **Always use the user parameter** - Never rely on `auth()->user()` inside a policy

--- a/skills/laravel-specialist/references/broadcasting.md
+++ b/skills/laravel-specialist/references/broadcasting.md
@@ -1,0 +1,665 @@
+# Broadcasting
+
+## Installation
+
+```shell
+# Install with Reverb (first-party WebSocket server)
+php artisan install:broadcasting --reverb
+
+# Install with Pusher Channels
+php artisan install:broadcasting --pusher
+
+# Install without a driver (for Ably or manual setup)
+php artisan install:broadcasting
+```
+
+## Server-Side Drivers
+
+### Reverb (First-Party)
+
+```shell
+composer require laravel/reverb
+php artisan reverb:install
+php artisan reverb:start
+```
+
+Configure in `.env`:
+
+```
+REVERB_APP_ID=my-app-id
+REVERB_APP_KEY=my-app-key
+REVERB_APP_SECRET=my-app-secret
+REVERB_HOST="0.0.0.0"
+REVERB_PORT=8080
+REVERB_SCHEME=http
+
+VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
+VITE_REVERB_HOST="${REVERB_HOST}"
+VITE_REVERB_PORT="${REVERB_PORT}"
+VITE_REVERB_SCHEME="${REVERB_SCHEME}"
+```
+
+### Pusher Channels
+
+```
+PUSHER_APP_ID=my-app-id
+PUSHER_APP_KEY=my-app-key
+PUSHER_APP_SECRET=my-app-secret
+PUSHER_HOST=
+PUSHER_PORT=443
+PUSHER_SCHEME=https
+PUSHER_APP_CLUSTER=mt1
+
+VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
+VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+```
+
+### Ably
+
+```
+ABLY_KEY=my-ably-key
+VITE_ABLY_PUBLIC_KEY=my-ably-public-key
+```
+
+Ensure Pusher protocol support is enabled in Ably app settings.
+
+## Client-Side Installation (Laravel Echo)
+
+### JavaScript (Pusher Protocol)
+
+```js
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_PUSHER_APP_KEY,
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER,
+    forceTLS: true,
+});
+```
+
+### JavaScript (Reverb)
+
+```js
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'reverb',
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});
+```
+
+### JavaScript (Ably)
+
+```js
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_ABLY_PUBLIC_KEY,
+    wsHost: 'realtime-pusher.ably.io',
+    wsPort: 443,
+    disableStats: true,
+    encrypted: true,
+});
+```
+
+### React
+
+```js
+import { configureEcho } from "@laravel/echo-react";
+
+configureEcho({
+    broadcaster: "reverb",
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT,
+    wssPort: import.meta.env.VITE_REVERB_PORT,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});
+```
+
+### Vue
+
+```js
+import { configureEcho } from "@laravel/echo-vue";
+
+configureEcho({
+    broadcaster: "reverb",
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT,
+    wssPort: import.meta.env.VITE_REVERB_PORT,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});
+```
+
+### Svelte
+
+```js
+import { configureEcho } from "@laravel/echo-svelte";
+
+configureEcho({
+    broadcaster: "reverb",
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT,
+    wssPort: import.meta.env.VITE_REVERB_PORT,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});
+```
+
+## Defining Broadcast Events
+
+Implement `ShouldBroadcast` on any event class:
+
+```php
+<?php
+
+namespace App\Events;
+
+use App\Models\Order;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Queue\SerializesModels;
+
+class OrderShipped implements ShouldBroadcast
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Order $order,
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('user.' . $this->order->user_id),
+        ];
+    }
+}
+```
+
+Use `ShouldBroadcastNow` to dispatch synchronously (not queued):
+
+```php
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+
+class OrderShipped implements ShouldBroadcastNow
+{
+    // ...
+}
+```
+
+### Customizing the Event Name
+
+```php
+public function broadcastAs(): string
+{
+    return 'order.shipped';
+}
+```
+
+On the client, listen with the custom name:
+
+```js
+Echo.private('user.1')
+    .listen('.order.shipped', (e) => {
+        console.log(e.order);
+    });
+```
+
+### Customizing the Data Payload
+
+```php
+public function broadcastWith(): array
+{
+    return ['id' => $this->order->id, 'status' => 'shipped'];
+}
+```
+
+### Conditional Broadcasting
+
+```php
+public function broadcastWhen(): bool
+{
+    return $this->order->status === 'shipped';
+}
+```
+
+## Channel Types
+
+```php
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+
+// Public — anyone can listen
+new Channel('orders');
+
+// Private — requires authorization
+new PrivateChannel('user.' . $userId);
+
+// Presence — auth + member tracking
+new PresenceChannel('chat.' . $roomId);
+```
+
+## Authorizing Channels
+
+Define authorization in `routes/channels.php`:
+
+```php
+use App\Models\Order;
+use App\Models\User;
+
+// Simple callback
+Broadcast::channel('orders.{orderId}', function (User $user, int $orderId) {
+    return $user->id === Order::findOrNew($orderId)->user_id;
+});
+
+// With model binding
+Broadcast::channel('orders.{order}', function (User $user, Order $order) {
+    return $user->id === $order->user_id;
+});
+```
+
+### Channel Classes
+
+```php
+<?php
+
+namespace App\Broadcasting;
+
+use App\Models\Order;
+use App\Models\User;
+
+class OrderChannel
+{
+    public function join(User $user, Order $order): bool
+    {
+        return $user->id === $order->user_id;
+    }
+}
+```
+
+Register in `routes/channels.php`:
+
+```php
+use App\Broadcasting\OrderChannel;
+
+Broadcast::channel('orders.{order}', OrderChannel::class);
+```
+
+## Broadcasting Events
+
+```php
+// Via the event helper
+event(new OrderShipped($order));
+
+// Via the broadcast facade
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::event(new OrderShipped($order));
+
+// Via the broadcast helper (returns the event for chaining)
+broadcast(new OrderShipped($order));
+```
+
+### Broadcasting to Others
+
+Exclude the current user from receiving the broadcast:
+
+```php
+broadcast(new OrderShipped($order))->toOthers();
+```
+
+The receiving client must enable the `wh-channel` header:
+
+```js
+window.Echo = new Echo({
+    broadcaster: 'reverb',
+    // ...
+    whChannel: 'App.Models.User.' + userId,
+});
+```
+
+### Anonymous Events (No Event Class)
+
+```php
+use Illuminate\Support\Facades\Broadcast;
+
+// Public channel
+Broadcast::on('orders.' . $order->id)->send();
+
+// With custom name and data
+Broadcast::on('orders.' . $order->id)
+    ->as('OrderPlaced')
+    ->with($order)
+    ->send();
+
+// Private channel
+Broadcast::private('orders.' . $order->id)->send();
+
+// Presence channel
+Broadcast::presence('channels.' . $channel->id)->send();
+
+// Exclude current user
+Broadcast::on('orders.' . $order->id)
+    ->toOthers()
+    ->send();
+```
+
+## Receiving Broadcasts via Echo
+
+### React
+
+```jsx
+import { useEcho } from "@laravel/echo-react";
+
+function OrderStatus({ orderId }) {
+    useEcho(`orders.${orderId}`, (e) => {
+        console.log('Order updated:', e);
+    });
+
+    useEcho(`orders.${orderId}`, {
+        onOrderShipped: (e) => console.log('Shipped:', e),
+    });
+}
+```
+
+### Vue
+
+```vue
+<script setup>
+import { useEcho } from "@laravel/echo-vue";
+
+useEcho(`orders.${props.orderId}`, (e) => {
+    console.log('Order updated:', e);
+});
+
+useEcho(`orders.${props.orderId}`, {
+    onOrderShipped: (e) => console.log('Shipped:', e),
+});
+</script>
+```
+
+### Svelte
+
+```svelte
+<script>
+    import { useEcho } from "@laravel/echo-svelte";
+
+    useEcho(`orders.${orderId}`, (e) => {
+        console.log('Order updated:', e);
+    });
+
+    useEcho(`orders.${orderId}`, {
+        onOrderShipped: (e) => console.log('Shipped:', e),
+    });
+</script>
+```
+
+### Vanilla JS
+
+```js
+// Private channel
+Echo.private('orders.' + orderId)
+    .listen('OrderShipped', (e) => {
+        console.log(e.order);
+    })
+    .listen('.order.shipped', (e) => {
+        console.log('Custom event name:', e);
+    })
+    .notification((notification) => {
+        console.log('Broadcast notification:', notification);
+    });
+
+// Public channel
+Echo.channel('orders')
+    .listen('OrderCreated', (e) => {
+        console.log(e.order);
+    });
+
+// Listening for a single event
+Echo.private('orders.' + orderId)
+    .listenOnce('OrderShipped', (e) => {
+        console.log('First shipment only:', e);
+    });
+```
+
+## Presence Channels
+
+```php
+<?php
+
+namespace App\Events;
+
+use App\Models\Message;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class NewMessage implements ShouldBroadcast
+{
+    use InteractsWithSockets;
+
+    public function __construct(
+        public Message $message,
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PresenceChannel('chat.' . $this->message->room_id),
+        ];
+    }
+}
+```
+
+### Authorizing Presence Channels
+
+```php
+use App\Models\ChatRoom;
+use App\Models\User;
+
+Broadcast::channel('chat.{room}', function (User $user, ChatRoom $room) {
+    return $room->members->contains($user)
+        ? ['id' => $user->id, 'name' => $user->name, 'avatar' => $user->avatar_url]
+        : false;
+});
+```
+
+### Client-Side Presence
+
+```js
+Echo.join(`chat.${roomId}`)
+    .here((members) => {
+        console.log('Current members:', members);
+    })
+    .joining((member) => {
+        console.log('Joined:', member);
+    })
+    .leaving((member) => {
+        console.log('Left:', member);
+    })
+    .listen('NewMessage', (e) => {
+        console.log('Message:', e.message);
+    })
+    .error((error) => {
+        console.error('Presence error:', error);
+    });
+```
+
+## Model Broadcasting
+
+Use the `BroadcastsEvents` trait on an Eloquent model:
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Database\Eloquent\BroadcastsEvents;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use BroadcastsEvents, HasFactory;
+
+    public function broadcastOn(string $event): array
+    {
+        return [$this, $this->user];
+    }
+
+    public function broadcastAs(string $event): string|null
+    {
+        return match ($event) {
+            'created' => 'post.created',
+            'updated' => 'post.updated',
+            'deleted' => 'post.deleted',
+            default => null,
+        };
+    }
+
+    public function broadcastWith(string $event): array
+    {
+        return match ($event) {
+            'created' => ['title' => $this->title],
+            default => ['model' => $this],
+        };
+    }
+
+    public function broadcastWhen(string $event): bool
+    {
+        return match ($event) {
+            'deleted' => false,
+            default => true,
+        };
+    }
+}
+```
+
+Model events `created`, `updated`, `deleted`, `trashed`, and `restored` are broadcast automatically.
+
+### Listening to Model Broadcasts
+
+```js
+Echo.private(`App.Models.User.${this.user.id}`)
+    .listen('.post.created', (e) => {
+        console.log('New post:', e.model);
+    });
+
+Echo.private(`App.Models.Post.${postId}`)
+    .listen('.post.updated', (e) => {
+        console.log('Post updated:', e.model);
+    });
+```
+
+## Client Events
+
+Broadcast directly from the client without hitting your server:
+
+```js
+Echo.private('orders.1')
+    .whisper('typing', { username: user.name });
+
+Echo.private('orders.1')
+    .listenForWhisper('typing', (e) => {
+        console.log(`${e.username} is typing...`);
+    });
+```
+
+Enable on the server in `config/broadcasting.php`:
+
+```php
+'connections' => [
+    'reverb' => [
+        // ...
+        'client_events' => [
+            'typing',
+            'cancel-typing',
+        ],
+    ],
+],
+```
+
+## Notifications via Broadcast Channel
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class InvoicePaid extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        private int $invoiceId,
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['broadcast'];
+    }
+
+    public function toBroadcast(object $notifiable): array
+    {
+        return [
+            'invoice_id' => $this->invoiceId,
+            'amount' => 100,
+        ];
+    }
+
+    public function broadcastType(): string
+    {
+        return 'invoice.paid';
+    }
+}
+```
+
+### Receiving Broadcast Notifications
+
+```js
+Echo.private('App.Models.User.' + userId)
+    .notification((notification) => {
+        console.log('New notification:', notification);
+    });
+```
+
+## Best Practices
+
+1. **Always use private/presence channels for user-specific data** — never send sensitive data over public channels
+2. **Use `broadcastAs()` to define custom event names** — decouples client from class names
+3. **Use `broadcastWith()` to control payload size** — only send what the client needs
+4. **Use `toOthers()` to prevent duplicate processing** — the sender already has the state
+5. **Name channels using dot notation** — `orders.{id}`, `users.{id}`, `chat.{room}`
+6. **Keep model broadcasting payloads small** — avoid sending full model graphs
+7. **Enable `client_events` sparingly** — validate on the server if needed
+8. **Use `broadcastWhen()` to avoid unnecessary broadcasts** — especially for model events
+9. **Use Echo framework packages** — `@laravel/echo-react`, `@laravel/echo-vue`, `@laravel/echo-svelte` provide lifecycle-aware hooks
+10. **Use notifications for ephemeral alerts** — the broadcast channel is ideal for real-time push notifications

--- a/skills/laravel-specialist/references/collections.md
+++ b/skills/laravel-specialist/references/collections.md
@@ -1,0 +1,877 @@
+# Collections
+
+## Introduction
+
+Laravel's `Illuminate\Support\Collection` provides a fluent, immutable wrapper for working with arrays of data. Every method returns a new `Collection` instance unless otherwise noted, allowing method chaining without mutating the original. The `collect()` helper creates a new collection from any array, iterable, or `null`.
+
+```php
+$collection = collect([1, 2, 3]);
+
+// Methods return new instances — original is never mutated
+$filtered = $collection->filter(fn (int $v) => $v > 1);
+// $collection: [1, 2, 3]  (unchanged)
+// $filtered:   [2 => 2, 3 => 3]  (new instance)
+```
+
+## Creating Collections
+
+```php
+use Illuminate\Support\Collection;
+
+// collect() helper — most common
+$c = collect([1, 2, 3]);
+
+// Collection::make()
+$c = Collection::make(['a', 'b']);
+
+// Collection::fromJson()
+$c = Collection::fromJson('{"name": "John", "age": 30}');
+// ['name' => 'John', 'age' => 30]
+
+// Collection::times() — call a closure N times
+$c = Collection::times(3, fn (int $i) => $i * 2);
+// [2, 4, 6]
+
+// Collection::range() — inclusive numeric range (Laravel 12+)
+$c = Collection::range(1, 5);
+// [1, 2, 3, 4, 5]
+
+$c = Collection::range(1, 10, 3);  // step of 3
+// [1, 4, 7, 10]
+```
+
+## Extending Collections
+
+```php
+use Illuminate\Support\Collection;
+
+// Register a macro once (typically in AppServiceProvider::boot())
+Collection::macro('toUpper', function () {
+    return $this->map(fn (string $value) => strtoupper($value));
+});
+
+// Usage
+collect(['foo', 'bar'])->toUpper();
+// ['FOO', 'BAR']
+
+// Macro with arguments
+Collection::macro('prefixed', function (string $prefix) {
+    return $this->map(fn (string $value) => $prefix.$value);
+});
+
+collect(['a', 'b'])->prefixed('item_');
+// ['item_a', 'item_b']
+```
+
+## Available Methods
+
+### Filtering & Slicing
+
+```php
+// filter() — keep items where callback returns truthy (keeps keys)
+collect([1, 2, 3, 4])->filter(fn (int $v) => $v > 2);
+// [2 => 3, 3 => 4]
+
+// reject() — inverse of filter
+collect([1, 2, 3, 4])->reject(fn (int $v) => $v > 2);
+// [0 => 1, 1 => 2]
+
+// first() — first passing truth test, or first item
+collect([1, 2, 3])->first(fn (int $v) => $v > 1);
+// 2
+
+collect([1, 2, 3])->first();
+// 1
+
+// firstOrFail() — same as first() but throws ItemNotFoundException
+collect([1, 2, 3])->firstOrFail(fn (int $v) => $v > 2);
+// 3
+
+collect([1, 2, 3])->firstOrFail(fn (int $v) => $v > 5);
+// throws Illuminate\Support\ItemNotFoundException
+
+// firstWhere() — first item matching key/value
+$data = collect([['name' => 'John', 'age' => 30], ['name' => 'Jane', 'age' => 25]]);
+$data->firstWhere('name', 'Jane');
+// ['name' => 'Jane', 'age' => 25]
+
+// last() — last passing truth test, or last item
+collect([1, 2, 3])->last(fn (int $v) => $v < 3);
+// 2
+
+// only() — items with specified keys
+collect(['a' => 1, 'b' => 2, 'c' => 3])->only(['a', 'c']);
+// ['a' => 1, 'c' => 3]
+
+// except() — items excluding specified keys
+collect(['a' => 1, 'b' => 2, 'c' => 3])->except(['a']);
+// ['b' => 2, 'c' => 3]
+
+// slice() — extract a portion with offset and optional length
+collect([1, 2, 3, 4, 5])->slice(2, 2);
+// [2 => 3, 3 => 4]
+
+// skip() — skip N items from the beginning
+collect([1, 2, 3, 4])->skip(2);
+// [2 => 3, 3 => 4]
+
+// skipUntil() — skip until callback returns true, then include everything
+collect([1, 1, 2, 3])->skipUntil(fn (int $v) => $v >= 2);
+// [2 => 2, 3 => 3]
+
+// skipWhile() — skip while callback returns true, then include the rest
+collect([1, 1, 2, 3])->skipWhile(fn (int $v) => $v === 1);
+// [2 => 2, 3 => 3]
+
+// take() — first N items (negative N takes from the end)
+collect([1, 2, 3, 4])->take(2);
+// [0 => 1, 1 => 2]
+
+collect([1, 2, 3, 4])->take(-2);
+// [2 => 3, 3 => 4]
+
+// takeUntil() — take items until callback returns true, then stop
+collect([1, 1, 2, 3])->takeUntil(fn (int $v) => $v >= 2);
+// [0 => 1, 1 => 1]
+
+// takeWhile() — take items while callback returns true, then stop
+collect([1, 1, 2, 3])->takeWhile(fn (int $v) => $v === 1);
+// [0 => 1, 1 => 1]
+
+// where() — simple key/value filter (loose comparison)
+$data = collect([['name' => 'John'], ['name' => 'Jane']]);
+$data->where('name', 'John');
+// [0 => ['name' => 'John']]
+
+// whereStrict() — strict comparison (===)
+$data->whereStrict('name', 'John');
+
+// whereBetween() — where column is between two values
+collect([['price' => 100], ['price' => 200], ['price' => 300]])
+    ->whereBetween('price', [150, 250]);
+// [1 => ['price' => 200]]
+
+// whereNotBetween() — inverse of whereBetween
+collect([['v' => 1], ['v' => 2], ['v' => 3]])->whereNotBetween('v', [1, 2]);
+// [2 => ['v' => 3]]
+
+// whereIn() — where value is in given array (loose)
+collect([['v' => 1], ['v' => 2]])->whereIn('v', [1, 3]);
+// [0 => ['v' => 1]]
+
+// whereNotIn() — inverse of whereIn
+collect([['v' => 1], ['v' => 2]])->whereNotIn('v', [1]);
+// [1 => ['v' => 2]]
+
+// whereInstanceOf() — filter by class
+collect([new stdClass, new stdClass, new DateTime])
+    ->whereInstanceOf(stdClass::class);
+// [0 => stdClass, 1 => stdClass]
+
+// whereNull() — items where key is null
+collect([['a' => 1], ['a' => null]])->whereNull('a');
+// [1 => ['a' => null]]
+
+// whereNotNull() — items where key is not null
+collect([['a' => 1], ['a' => null]])->whereNotNull('a');
+// [0 => ['a' => 1]]
+```
+
+### Mapping & Transforming
+
+```php
+// map() — transform every item (returns keys from 0)
+collect([1, 2, 3])->map(fn (int $v) => $v * 10);
+// [0 => 10, 1 => 20, 2 => 30]
+
+// mapInto() — instantiate class with each item as constructor arg
+collect([1, 2])->mapInto(stdClass::class);
+// [0 => stdClass {1}, 1 => stdClass {2}]
+
+// mapSpread() — iterate over nested arrays, spread into callback
+collect([[1, 2], [3, 4]])
+    ->mapSpread(fn (int $a, int $b) => $a + $b);
+// [0 => 3, 1 => 7]
+
+// mapToGroups() — group by callback returning key/value pair
+$data = collect([
+    ['name' => 'John', 'dept' => 'Sales'],
+    ['name' => 'Jane', 'dept' => 'Sales'],
+    ['name' => 'Jim',  'dept' => 'Marketing'],
+]);
+$data->mapToGroups(fn (array $item) => [$item['dept'] => $item['name']]);
+// ['Sales' => ['John', 'Jane'], 'Marketing' => ['Jim']]
+
+// mapWithKeys() — map to new collection with custom keys
+collect([['id' => 1, 'name' => 'John'], ['id' => 2, 'name' => 'Jane']])
+    ->mapWithKeys(fn (array $item) => [$item['id'] => $item['name']]);
+// [1 => 'John', 2 => 'Jane']
+
+// flatMap() — map and flatten one level
+collect([['name' => 'John'], ['name' => 'Jane']])
+    ->flatMap(fn (array $item) => [$item['name'] => strtoupper($item['name'])]);
+// ['John' => 'JOHN', 'Jane' => 'JANE']
+
+// flatten() — flatten multi-dimensional array to a single level
+collect([1, [2, [3, [4]]]])->flatten();
+// [1, 2, 3, 4]
+
+collect([1, [2, [3, [4]]]])->flatten(depth: 2);
+// [1, 2, 3, [4]]
+
+// collapse() — collapse array of arrays into a flat collection
+collect([[1, 2], [3, 4], [5]])->collapse();
+// [0 => 1, 1 => 2, 2 => 3, 3 => 4, 4 => 5]
+
+// collapseWithKeys() — collapse while preserving original keys
+collect([
+    ['first'  => collect([1, 2, 3])],
+    ['second' => [4, 5, 6]],
+])->collapseWithKeys();
+// ['first' => [1, 2, 3], 'second' => [4, 5, 6]]
+```
+
+### Testing Conditions
+
+```php
+// contains() — does any item pass? (loose comparison for values)
+collect([1, 2, 3])->contains(fn (int $v) => $v > 2);
+// true
+
+collect(['name' => 'John'])->contains('John');
+// true
+
+collect([['name' => 'John']])->contains('name', 'John');
+// true
+
+// containsStrict() — same as contains but with strict comparison
+collect([1, '1'])->containsStrict('1');
+// true
+
+collect([1, '1'])->containsStrict(1);
+// true
+
+// doesntContain() — does no item pass?
+collect([1, 2, 3])->doesntContain(fn (int $v) => $v > 5);
+// true
+
+// doesntContainStrict() — strict version of doesntContain
+
+// every() — does every item pass?
+collect([2, 4, 6])->every(fn (int $v) => $v % 2 === 0);
+// true
+
+// some() — alias of contains()
+collect([1, 2, 3])->some(fn (int $v) => $v === 2);
+// true
+
+// isEmpty() — is the collection empty?
+collect([])->isEmpty();
+// true
+
+// isNotEmpty() — is the collection not empty?
+collect([1])->isNotEmpty();
+// true
+
+// has() — do all given keys exist?
+collect(['a' => 1, 'b' => 2])->has('a');
+// true
+
+collect(['a' => 1, 'b' => 2])->has(['a', 'b']);
+// true
+
+// hasAny() — does at least one key exist?
+collect(['a' => 1])->hasAny(['a', 'b']);
+// true
+
+// hasSole() — does the collection contain exactly one item matching criteria?
+collect([])->hasSole();
+// false
+
+collect([1])->hasSole();
+// true
+
+collect([1, 2, 3])->hasSole(fn (int $v) => $v === 2);
+// true
+
+// ensure() — assert all items are of a given type
+collect([1, 2, 3])->ensure('int');
+// [1, 2, 3]  (passes — returns the collection)
+
+collect([1, 'a', 3])->ensure('int');
+// throws UnexpectedValueException
+
+collect($users)->ensure(User::class);
+// passes if all items are User instances
+```
+
+### Searching & Retrieving
+
+```php
+// search() — find the first key matching value or callback
+collect(['a' => 1, 'b' => 2])->search(2);
+// 'b'
+
+collect([1, 2, 3])->search(fn (int $v) => $v > 2);
+// 2 (key)
+
+// get() — retrieve value by key with optional default
+collect(['a' => 1, 'b' => 2])->get('a');
+// 1
+
+collect(['a' => 1])->get('b', 0);
+// 0
+
+collect(['a' => 1])->get('b', fn () => 0);
+// 0
+
+// pluck() — extract values of a key, optionally keyed by another
+$data = collect([
+    ['id' => 1, 'name' => 'John'],
+    ['id' => 2, 'name' => 'Jane'],
+]);
+$data->pluck('name');
+// [0 => 'John', 1 => 'Jane']
+
+$data->pluck('name', 'id');
+// [1 => 'John', 2 => 'Jane']
+
+// keys() — return all keys
+collect(['a' => 1, 'b' => 2])->keys();
+// ['a', 'b']
+
+// values() — reset keys to sequential 0-based integers
+collect(['a' => 1, 'b' => 2])->values();
+// [0 => 1, 1 => 2]
+
+// sole() — return exactly one item matching callback, throws if none or many
+collect([1, 2, 3])->sole(fn (int $v) => $v === 2);
+// 2
+
+collect([1, 1])->sole(fn (int $v) => $v === 1);
+// throws ItemNotFoundException (multiple matches)
+
+// find() — return all items matching a truth test
+collect([1, 2, 3, 4])->find(fn (int $v) => $v > 2);
+// [2 => 3, 3 => 4]
+
+// value() — get a single value from the first item by key
+collect([['name' => 'John'], ['name' => 'Jane']])->value('name');
+// 'John'
+
+// random() — return one or more random items
+collect([1, 2, 3, 4])->random();
+// 3 (random)
+
+collect([1, 2, 3, 4])->random(2);
+// [2, 4] (random, collection)
+```
+
+### Sorting & Ordering
+
+```php
+// sort() — sort by value (keeps keys)
+collect([3, 1, 2])->sort();
+// [1 => 1, 2 => 2, 0 => 3]
+
+// sortBy() — sort by key or callback
+$data = collect([['name' => 'John'], ['name' => 'Jane']]);
+$data->sortBy('name');
+// [1 => ['name' => 'Jane'], 0 => ['name' => 'John']]
+
+$data->sortBy(fn (array $item) => $item['name']);
+// [1 => ['name' => 'Jane'], 0 => ['name' => 'John']]
+
+// sortByDesc() — descending sortBy
+$data->sortByDesc('name');
+// [0 => ['name' => 'John'], 1 => ['name' => 'Jane']]
+
+// sortDesc() — descending sort (same as sort()->reverse())
+collect([3, 1, 2])->sortDesc();
+// [2 => 3, 0 => 1, 1 => 2]  (values descending, keys preserved)
+
+// sortKeys() — sort by keys
+collect(['c' => 3, 'a' => 1, 'b' => 2])->sortKeys();
+// ['a' => 1, 'b' => 2, 'c' => 3]
+
+// sortKeysDesc() — descending sort by keys
+collect(['a' => 1, 'c' => 3, 'b' => 2])->sortKeysDesc();
+// ['c' => 3, 'b' => 2, 'a' => 1]
+
+// sortKeysUsing() — sort by keys using a custom comparison
+collect(['a' => 1, 'C' => 3, 'b' => 2])
+    ->sortKeysUsing(strcasecmp(...));
+// ['a' => 1, 'b' => 2, 'C' => 3]
+
+// reverse() — reverse the order (keeps keys)
+collect([1, 2, 3])->reverse();
+// [2 => 3, 1 => 2, 0 => 1]
+```
+
+### Math
+
+```php
+// avg() / average() — average of values
+collect([1, 2, 3])->avg();
+// 2
+
+collect([['price' => 10], ['price' => 20]])->avg('price');
+// 15
+
+// median() — median value
+collect([1, 2, 3, 4, 5])->median();
+// 3
+
+collect([['price' => 10], ['price' => 20], ['price' => 30]])->median('price');
+// 20
+
+// mode() — most frequently occurring value(s)
+collect([1, 1, 2, 3])->mode();
+// [1]
+
+collect([1, 1, 2, 2])->mode();
+// [1, 2]
+
+// min() — minimum value
+collect([3, 1, 2])->min();
+// 1
+
+collect([['price' => 30], ['price' => 10]])->min('price');
+// 10
+
+// max() — maximum value
+collect([3, 1, 2])->max();
+// 3
+
+// sum() — sum of values
+collect([1, 2, 3])->sum();
+// 6
+
+collect([['price' => 10], ['price' => 20]])->sum('price');
+// 30
+
+// count() — number of items
+collect([1, 2, 3])->count();
+// 3
+
+// countBy() — count occurrences of each value
+collect([1, 1, 2, 2, 2, 3])->countBy();
+// [1 => 2, 2 => 3, 3 => 1]
+
+collect(['foo', 'bar', 'foo'])->countBy();
+// ['foo' => 2, 'bar' => 1]
+
+// percentage() — percentage of items passing a truth test (Laravel 12+)
+collect([1, 1, 2, 2, 2, 3])->percentage(fn (int $v) => $v === 1);
+// 33.33
+```
+
+### Aggregation & Reduction
+
+```php
+// reduce() — reduce to a single value
+collect([1, 2, 3])->reduce(fn (int $carry, int $item) => $carry + $item, 0);
+// 6
+
+// reduceSpread() — reduce to multiple values using array destructuring
+[$creditsRemaining, $batch] = collect($images)
+    ->reduceSpread(
+        fn (int $credits, Collection $batch, $image) => $image->requiresCredits()
+            ? [$credits - 5, $batch->push($image)]
+            : [$credits, $batch],
+        $availableCredits,
+        collect(),
+    );
+
+// pipe() — pass the collection to a closure, return the result
+collect([1, 2, 3])->pipe(fn (Collection $c) => $c->sum());
+// 6
+
+// pipeInto() — create a new instance of a class with collection as constructor arg
+collect([1, 2, 3])->pipeInto(ResourceCollection::class);
+// ResourceCollection instance with $collection property
+
+// pipeThrough() — pass collection through an array of pipes
+collect([1, 2, 3])->pipeThrough([
+    fn (Collection $c) => $c->merge([4, 5]),
+    fn (Collection $c) => $c->sum(),
+]);
+// 15
+
+// tap() — pass collection to a closure for side effects, return the collection
+collect([1, 2, 3])->tap(function (Collection $c) {
+    logger('Collection size: '.$c->count());
+});
+// [1, 2, 3] (unchanged)
+```
+
+### Set Operations
+
+```php
+// diff() — items not present in the given collection (value comparison)
+collect([1, 2, 3])->diff([2, 4]);
+// [0 => 1, 2 => 3]
+
+// diffAssoc() — items whose key/value pairs differ
+collect(['a' => 1, 'b' => 2])->diffAssoc(['a' => 1, 'b' => 3]);
+// ['b' => 2]
+
+// diffAssocUsing() — diffAssoc with a custom key comparison callback
+collect(['a' => 1, 'B' => 2])->diffAssocUsing(
+    ['a' => 1, 'b' => 3],
+    strcasecmp(...),
+);
+// ['B' => 2]
+
+// diffKeys() — items whose keys are not in the given collection
+collect(['a' => 1, 'b' => 2])->diffKeys(['a' => 1, 'c' => 3]);
+// ['b' => 2]
+
+// intersect() — items present in both collections (value comparison)
+collect([1, 2, 3])->intersect([2, 4]);
+// [1 => 2]
+
+// intersectUsing() — intersect with a custom value comparison callback
+collect([1, 2, 3])->intersectUsing([2, 4], fn (int $a, int $b) => $a <=> $b);
+// [1 => 2]
+
+// intersectAssoc() — items whose key/value pairs match
+collect(['a' => 1, 'b' => 2])->intersectAssoc(['a' => 1, 'b' => 3]);
+// ['a' => 1]
+
+// intersectAssocUsing() — intersectAssoc with custom key comparison
+collect(['a' => 1, 'B' => 2])->intersectAssocUsing(
+    ['a' => 1, 'b' => 3],
+    strcasecmp(...),
+);
+// ['a' => 1]
+
+// intersectByKeys() — items whose keys exist in the given collection
+collect(['a' => 1, 'b' => 2])->intersectByKeys(['a' => 1, 'c' => 3]);
+// ['a' => 1]
+
+// unique() — unique values (loose comparison, keeps first occurrence)
+collect([1, 1, 2, 3])->unique();
+// [0 => 1, 2 => 2, 3 => 3]
+
+collect([['name' => 'John'], ['name' => 'Jane'], ['name' => 'John']])
+    ->unique('name');
+// [0 => ['name' => 'John'], 1 => ['name' => 'Jane']]
+
+// uniqueStrict() — same as unique but with strict (===) comparison
+
+// duplicates() — retrieve duplicate values
+collect(['a', 'b', 'a', 'c', 'b'])->duplicates();
+// [2 => 'a', 4 => 'b']
+
+// duplicatesStrict() — strict version of duplicates
+```
+
+### Arrays & Conversion
+
+```php
+// toArray() — convert collection to a plain PHP array
+collect([1, 2, 3])->toArray();
+// [1, 2, 3]
+
+// toJson() — convert to JSON string
+collect(['name' => 'John', 'age' => 30])->toJson();
+// '{"name":"John","age":30}'
+
+// toPrettyJson() — pretty-printed JSON (Laravel 12+)
+collect(['name' => 'John'])->toPrettyJson();
+// '{
+//     "name": "John"
+// }'
+
+// all() — return the underlying array
+collect([1, 2, 3])->all();
+// [1, 2, 3]
+
+// implode() — join items into a string
+collect([1, 2, 3])->implode('-');
+// '1-2-3'
+
+collect([['product' => 'Desk'], ['product' => 'Chair']])
+    ->implode('product', ', ');
+// 'Desk, Chair'
+
+// Using a closure as first argument (Laravel 12+)
+collect([['product' => 'Desk'], ['product' => 'Chair']])
+    ->implode(fn (array $item) => strtoupper($item['product']), ', ');
+// 'DESK, CHAIR'
+
+// join() — join items with separator, with final separator
+collect(['a', 'b', 'c'])->join(', ');
+// 'a, b, c'
+
+collect(['a', 'b', 'c'])->join(', ', ' and ');
+// 'a, b and c'
+
+// dd() — dump and die
+collect([1, 2, 3])->dd();
+// dumps the collection and exits
+
+// dump() — dump without dying
+collect([1, 2, 3])->dump();
+// dumps the collection, returns the collection
+```
+
+### Adding & Removing
+
+```php
+// push() — append an item
+collect([1, 2])->push(3);
+// [0 => 1, 1 => 2, 2 => 3]
+
+// pop() — remove and return the last item
+$c = collect([1, 2, 3]);
+$last = $c->pop();
+// $last = 3, $c = [1, 2]
+
+// prepend() — add item to the beginning
+collect([1, 2, 3])->prepend(0);
+// [0 => 0, 1 => 1, 2 => 2, 3 => 3]
+
+// With key
+collect(['a' => 1])->prepend(0, 'z');
+// ['z' => 0, 'a' => 1]
+
+// pull() — remove and return a specific key
+$c = collect(['a' => 1, 'b' => 2]);
+$value = $c->pull('a');
+// $value = 1, $c = ['b' => 2]
+
+// put() — set a key/value pair
+collect(['a' => 1])->put('b', 2);
+// ['a' => 1, 'b' => 2]
+
+// shift() — remove and return the first item
+$c = collect([1, 2, 3]);
+$first = $c->shift();
+// $first = 1, $c = [1 => 2, 2 => 3]
+
+// splice() — remove and return a slice, optionally replacing it
+$c = collect([1, 2, 3, 4, 5]);
+$removed = $c->splice(2, 2, [10, 11]);
+// $removed = [3, 4], $c = [1, 2, 10, 11, 5]
+
+// forget() — remove items by key
+collect(['a' => 1, 'b' => 2])->forget('a');
+// ['b' => 2]
+
+// add() — add item only if key doesn't exist
+collect(['a' => 1])->add('b', 2);
+// ['a' => 1, 'b' => 2]
+
+collect(['a' => 1])->add('a', 2);
+// ['a' => 1]  (no-op, key already exists)
+```
+
+### Chunking & Splitting
+
+```php
+// chunk() — split into collections of given size
+collect([1, 2, 3, 4, 5])->chunk(2);
+// [[1, 2], [3, 4], [5]]  (collection of collections)
+
+// chunkWhile() — chunk based on a callback
+collect([1, 2, 3, 4, 5])->chunkWhile(
+    fn (int $value, int $key, Collection $chunk) => $value <= 3,
+);
+// [[1, 2, 3], [4, 5]]
+
+// split() — split into N equal-sized groups
+collect([1, 2, 3, 4, 5])->split(3);
+// [[1, 2], [3, 4], [5]]
+
+// splitIn() — split into N groups distributing remaining items
+collect([1, 2, 3, 4, 5])->splitIn(3);
+// [[1, 2], [3, 4], [5]]
+
+// sliding() — sliding window view
+collect([1, 2, 3, 4, 5])->sliding(2);
+// [[1, 2], [2, 3], [3, 4], [4, 5]]
+
+collect([1, 2, 3, 4])->sliding(2, step: 2);
+// [[1, 2], [3, 4]]
+
+// nth() — every Nth item
+collect([1, 2, 3, 4, 5])->nth(2);
+// [0 => 1, 2 => 3, 4 => 5]
+
+collect([1, 2, 3, 4, 5])->nth(2, offset: 1);
+// [1 => 2, 3 => 4]
+
+// forPage() — items for a given page number
+collect(range(1, 20))->forPage(2, 5);
+// [5 => 6, 6 => 7, 7 => 8, 8 => 9, 9 => 10]
+```
+
+### Combining & Merging
+
+```php
+// combine() — use one collection as keys, another as values
+collect(['name', 'age'])->combine(['John', 30]);
+// ['name' => 'John', 'age' => 30]
+
+// concat() — append items from an array or collection
+collect([1, 2])->concat([3, 4]);
+// [0 => 1, 1 => 2, 2 => 3, 3 => 4]
+
+// crossJoin() — cross join (Cartesian product)
+collect([1, 2])->crossJoin(['a', 'b']);
+// [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
+
+// merge() — merge arrays (numeric keys are appended, string keys overwrite)
+collect(['a' => 1, 'b' => 2])->merge(['b' => 10]);
+// ['a' => 1, 'b' => 10]
+
+collect([1, 2])->merge([3, 4]);
+// [0 => 1, 1 => 2, 2 => 3, 3 => 4]
+
+// mergeRecursive() — recursive merge
+collect(['a' => ['b' => 1]])->mergeRecursive(['a' => ['c' => 2]]);
+// ['a' => ['b' => 1, 'c' => 2]]
+
+// replace() — replace values at matching keys (works like array_replace)
+collect(['a' => 1, 'b' => 2])->replace(['a' => 10, 'c' => 3]);
+// ['a' => 10, 'b' => 2, 'c' => 3]
+
+// replaceRecursive() — recursive version of replace
+collect(['a' => ['b' => 1]])->replaceRecursive(['a' => ['b' => 10]]);
+// ['a' => ['b' => 10]]
+
+// union() — add items with keys not already present
+collect(['a' => 1, 'b' => 2])->union(['b' => 20, 'c' => 30]);
+// ['a' => 1, 'b' => 2, 'c' => 30]
+
+// zip() — merge values from multiple collections element by element
+collect([1, 2, 3])->zip([4, 5, 6], ['a', 'b', 'c']);
+// [[1, 4, 'a'], [2, 5, 'b'], [3, 6, 'c']]
+```
+
+### Key Manipulation
+
+```php
+// keyBy() — key the collection by a given key
+$data = collect([
+    ['id' => 1, 'name' => 'John'],
+    ['id' => 2, 'name' => 'Jane'],
+]);
+$data->keyBy('id');
+// [1 => ['id' => 1, 'name' => 'John'], 2 => ['id' => 2, 'name' => 'Jane']]
+
+// Using a callback
+$data->keyBy(fn (array $item) => strtolower($item['name']));
+// ['john' => ['id' => 1, 'name' => 'John'], 'jane' => ['id' => 2, 'name' => 'Jane']]
+
+// flip() — swap keys and values
+collect(['a' => 1, 'b' => 2])->flip();
+// [1 => 'a', 2 => 'b']
+
+// dot() — flatten multi-dimensional array into dot notation (aliases: flattenDot, collapse)
+// Note: `dot()` is available via the Collection macro pattern; use `Arr::dot()` directly
+// for ad-hoc usage outside of chainable methods in some versions.
+collect(['user' => ['name' => 'John', 'profile' => ['age' => 30]]])->dot();
+// ['user.name' => 'John', 'user.profile.age' => 30]
+
+// undot() — expand dot notation keys back into nested arrays
+collect(['user.name' => 'John', 'user.profile.age' => 30])->undot();
+// ['user' => ['name' => 'John', 'profile' => ['age' => 30]]]
+```
+
+## Higher Order Messages
+
+Collections support higher order messages — dynamic properties that shortcut common method calls. Available for: `average`, `avg`, `contains`, `each`, `every`, `filter`, `first`, `flatMap`, `groupBy`, `keyBy`, `map`, `max`, `min`, `partition`, `reject`, `skipUntil`, `skipWhile`, `some`, `sortBy`, `sortByDesc`, `sum`, `takeUntil`, `takeWhile`, `unique`.
+
+```php
+use App\Models\User;
+
+$users = User::where('votes', '>', 500)->get();
+
+// Without higher order message
+$users->each(function (User $user) {
+    $user->markAsVip();
+});
+
+// With higher order message
+$users->each->markAsVip();
+
+// Mapping a property
+$names = $users->map->name->toArray();
+
+// Sum of a property
+$total = $users->sum->votes;
+```
+
+## Lazy Collections
+
+`LazyCollection` extends the same `Enumerable` contract but loads items on-demand, making it ideal for processing large datasets without exhausting memory. Use generators or the `lazy()` method on an existing collection.
+
+```php
+use Illuminate\Support\LazyCollection;
+
+// Using a generator
+$lazy = LazyCollection::make(function () {
+    $file = fopen('huge-file.csv', 'r');
+    while (($line = fgets($file)) !== false) {
+        yield $line;
+    }
+});
+
+// Process without loading entire file into memory
+$lazy->filter(fn (string $line) => str_contains($line, 'error'))
+    ->take(100)
+    ->each(fn (string $line) => logger($line));
+
+// Convert a regular collection to lazy
+$result = collect(range(1, 1_000_000))->lazy()
+    ->filter(fn (int $v) => $v % 2 === 0)
+    ->take(10)
+    ->all();
+// Only 10 items are ever materialized
+
+// LazyCollection from a query builder
+User::cursor()
+    ->filter(fn (User $user) => $user->isActive())
+    ->each(fn (User $user) => process($user));
+```
+
+## Enumerable Contract
+
+Both `Collection` and `LazyCollection` implement the `Illuminate\Support\Enumerable` contract. This contract defines the shared API (all methods listed above) while allowing each class to determine its own execution strategy — eager for `Collection`, lazy for `LazyCollection`.
+
+```php
+use Illuminate\Support\Enumerable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+// Type-hint against the contract when the execution strategy doesn't matter
+function processItems(Enumerable $items): Enumerable
+{
+    return $items->filter(fn ($item) => $item->isValid())
+        ->values();
+}
+
+// Accepts both Collection and LazyCollection
+processItems(collect([1, 2, 3]));
+processItems(LazyCollection::make(function () {
+    yield 1;
+    yield 2;
+    yield 3;
+}));
+```
+
+## Best Practices
+
+1. **Prefer collections over raw arrays** — Fluent API, immutability, and method chaining reduce bugs
+2. **Chain methods fluently** — Compose pipelines with `filter()` → `map()` → `values()` rather than nested loops
+3. **Use `lazy()` for large datasets** — Avoid memory exhaustion when processing thousands of items
+4. **Leverage higher order messages** — `$users->each->activate()` is clearer than `$users->each(fn ($u) => $u->activate())`
+5. **Type-hint with `Enumerable`** — Accept `Enumerable` rather than `Collection` when lazy execution is acceptable
+6. **Never mutate the original** — Collections are immutable; always assign the result to a new variable
+7. **Use `ensure()` for defensive programming** — Validate item types early in pipelines
+8. **Register macros sparingly** — Use `Collection::macro()` only for domain-specific operations used across the codebase
+9. **Prefer `sole()` when expecting exactly one item** — It throws on zero or multiple matches, preventing silent bugs
+10. **Use `percentage()` for readable proportions** — Avoid manual division operations in presentation logic

--- a/skills/laravel-specialist/references/concurrency.md
+++ b/skills/laravel-specialist/references/concurrency.md
@@ -1,0 +1,120 @@
+# Concurrency
+
+## Overview
+
+Execute multiple slow independent tasks in parallel for performance gains. Laravel serializes closures, dispatches them to hidden Artisan CLI commands in child PHP processes, then unserializes results back to the parent.
+
+## Drivers
+
+| Driver | Requires | Context | Notes |
+|--------|----------|---------|-------|
+| `process` (default) | Nothing | Any | Serializes closures to CLI subprocesses |
+| `fork` | `spatie/fork` | CLI only (no forking during web requests) | Better performance |
+| `sync` | Nothing | Testing | Executes sequentially in parent process, disables concurrency |
+
+Install fork driver:
+
+```bash
+composer require spatie/fork
+```
+
+Publish config to change default driver:
+
+```bash
+php artisan config:publish concurrency
+```
+
+```php
+<?php
+
+// config/concurrency.php
+'default' => 'fork',
+```
+
+## Running Concurrent Tasks
+
+### Basic Usage
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\DB;
+
+[$userCount, $orderCount] = Concurrency::run([
+    fn () => DB::table('users')->count(),
+    fn () => DB::table('orders')->count(),
+]);
+```
+
+### Named Results
+
+Access results by associative key instead of position:
+
+```php
+<?php
+
+$results = Concurrency::run([
+    'users' => fn () => DB::table('users')->count(),
+    'orders' => fn () => DB::table('orders')->count(),
+]);
+
+$userCount = $results['users'];
+$orderCount = $results['orders'];
+```
+
+### Specific Driver
+
+```php
+<?php
+
+$results = Concurrency::driver('fork')->run([...]);
+```
+
+### Task Timeouts
+
+Only supported for the `process` driver. Specify max seconds per task:
+
+```php
+<?php
+
+[$userCount, $orderCount] = Concurrency::run([
+    fn () => DB::table('users')->count(),
+    fn () => DB::table('orders')->count(),
+], timeout: 30);
+```
+
+Using `CarbonInterval`:
+
+```php
+<?php
+
+use function Illuminate\Support\seconds;
+
+Concurrency::run([...], timeout: seconds(30));
+```
+
+## Deferring Concurrent Tasks
+
+Run closures after the HTTP response is sent — no return values:
+
+```php
+<?php
+
+use App\Services\Metrics;
+use Illuminate\Support\Facades\Concurrency;
+
+Concurrency::defer([
+    fn () => Metrics::report('users'),
+    fn () => Metrics::report('orders'),
+]);
+```
+
+## Best Practices
+
+- Use `fork` driver in CLI commands/queue jobs for best performance
+- Use `sync` driver in tests to avoid complexity
+- Use named results for readability when you have 3+ tasks
+- Set timeouts for the `process` driver to prevent hung subprocesses
+- Use `defer` for non-critical background work that doesn't need results returned
+- Keep closures self-contained — they execute in isolation, so no shared in-memory state

--- a/skills/laravel-specialist/references/container.md
+++ b/skills/laravel-specialist/references/container.md
@@ -1,0 +1,553 @@
+# Service Container
+
+## Zero Configuration Resolution
+
+Dependencies are auto-resolved by type-hinting in constructors. No explicit binding needed when the class has no interface dependencies.
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Repositories\UserRepository;
+
+class UserController extends Controller
+{
+    public function __construct(
+        private UserRepository $users,
+    ) {}
+
+    public function index(): array
+    {
+        return $this->users->all()->toArray();
+    }
+}
+```
+
+This works for controllers, jobs, listeners, middleware, event handlers, and any class resolved by the container.
+
+## When to Use the Container Manually
+
+- Binding interfaces to implementations
+- Configuring singletons or scoped instances
+- Passing primitive values to constructors
+- Resolving classes with tagged dependencies
+- Registering contextual bindings for specific classes
+
+## Binding Basics
+
+### Simple Bindings
+
+```php
+use App\Services\Transistor;
+use App\Services\PodcastParser;
+use Illuminate\Contracts\Foundation\Application;
+
+$this->app->bind(Transistor::class, function (Application $app) {
+    return new Transistor($app->make(PodcastParser::class));
+});
+
+// Only register if not already bound
+$this->app->bindIf(Transistor::class, function (Application $app) {
+    return new Transistor($app->make(PodcastParser::class));
+});
+```
+
+### Singletons
+
+```php
+// Resolved once per application lifecycle
+$this->app->singleton(Transistor::class, function (Application $app) {
+    return new Transistor($app->make(PodcastParser::class));
+});
+
+$this->app->singletonIf(Transistor::class, function (Application $app) {
+    // Only registers if not already bound
+});
+```
+
+### Scoped Singletons
+
+```php
+// Resolved once per request/job lifecycle (flushed by Octane/queue workers)
+$this->app->scoped(Transistor::class, function (Application $app) {
+    return new Transistor($app->make(PodcastParser::class));
+});
+
+$this->app->scopedIf(Transistor::class, function (Application $app) {
+    // Only registers if not already bound
+});
+```
+
+### Instance Binding
+
+```php
+// Bind an existing object instance
+$service = new Transistor(new PodcastParser);
+$this->app->instance(Transistor::class, $service);
+```
+
+## PHP 8 Attributes
+
+### Singleton
+
+```php
+<?php
+
+namespace App\Services;
+
+use Illuminate\Container\Attributes\Singleton;
+
+#[Singleton]
+class Transistor
+{
+    // Resolved once per application lifecycle
+}
+```
+
+### Scoped
+
+```php
+<?php
+
+namespace App\Services;
+
+use Illuminate\Container\Attributes\Scoped;
+
+#[Scoped]
+class Transistor
+{
+    // Resolved once per request/job lifecycle
+}
+```
+
+## Binding Interfaces to Implementations
+
+```php
+$this->app->bind(
+    \App\Contracts\EventPusher::class,
+    \App\Services\RedisEventPusher::class
+);
+```
+
+### Using the `#[Bind]` Attribute
+
+Combine with `#[Singleton]` for singleton resolution:
+
+```php
+<?php
+
+namespace App\Contracts;
+
+use App\Services\RedisEventPusher;
+use Illuminate\Container\Attributes\Bind;
+use Illuminate\Container\Attributes\Singleton;
+
+#[Bind(RedisEventPusher::class)]
+#[Singleton]
+interface EventPusher
+{
+    public function push(string $event, array $data): void;
+}
+```
+
+Now type-hint `EventPusher` anywhere and the container resolves `RedisEventPusher` as a singleton.
+
+## Contextual Binding
+
+Bind different implementations based on the consuming class.
+
+### Basic Contextual Binding
+
+```php
+use App\Contracts\EventPusher;
+use App\Services\RedisEventPusher;
+use App\Services\SqsEventPusher;
+
+$this->app->when(OrderController::class)
+    ->needs(EventPusher::class)
+    ->give(RedisEventPusher::class);
+
+$this->app->when(ReportController::class)
+    ->needs(EventPusher::class)
+    ->give(SqsEventPusher::class);
+```
+
+### Primitives and Configuration
+
+```php
+$this->app->when(ReportAggregator::class)
+    ->needs('$timezone')
+    ->giveConfig('app.timezone');
+
+$this->app->when(ReportAggregator::class)
+    ->needs('$maxRetries')
+    ->give(3);
+```
+
+### Tagged Dependencies
+
+```php
+$this->app->when(ReportAggregator::class)
+    ->needs('$reports')
+    ->giveTagged('reports');
+
+// Typed variadic dependencies
+$this->app->when(Firewall::class)
+    ->needs(Filter::class)
+    ->give([
+        NullFilter::class,
+        ProfanityFilter::class,
+        TooLongFilter::class,
+    ]);
+```
+
+## Contextual Attributes
+
+Inject specific resources directly into constructors without configuration.
+
+### Auth
+
+```php
+use Illuminate\Container\Attributes\Auth;
+use Illuminate\Contracts\Auth\Guard;
+
+public function __construct(
+    #[Auth('web')] protected Guard $auth,
+) {}
+```
+
+### Cache
+
+```php
+use Illuminate\Container\Attributes\Cache;
+use Illuminate\Contracts\Cache\Repository;
+
+public function __construct(
+    #[Cache('redis')] protected Repository $cache,
+) {}
+```
+
+### Config
+
+```php
+use Illuminate\Container\Attributes\Config;
+
+public function __construct(
+    #[Config('app.timezone')] protected string $timezone,
+) {}
+```
+
+### Context (Request/Job Scoped Values)
+
+```php
+use Illuminate\Container\Attributes\Context;
+
+public function __construct(
+    #[Context('uuid')] protected string $uuid,
+    #[Context('ulid', hidden: true)] protected string $ulid,
+) {}
+```
+
+### DB
+
+```php
+use Illuminate\Container\Attributes\DB;
+use Illuminate\Database\Connection;
+
+public function __construct(
+    #[DB('mysql')] protected Connection $connection,
+) {}
+```
+
+### Log
+
+```php
+use Illuminate\Container\Attributes\Log;
+use Psr\Log\LoggerInterface;
+
+public function __construct(
+    #[Log('daily')] protected LoggerInterface $log,
+) {}
+```
+
+### Storage
+
+```php
+use Illuminate\Container\Attributes\Storage;
+use Illuminate\Contracts\Filesystem\Filesystem;
+
+public function __construct(
+    #[Storage('s3')] protected Filesystem $storage,
+) {}
+```
+
+### CurrentUser
+
+```php
+use App\Models\User;
+use Illuminate\Container\Attributes\CurrentUser;
+
+Route::get('/user', function (#[CurrentUser] User $user) {
+    return $user;
+})->middleware('auth');
+```
+
+### Tag
+
+```php
+use Illuminate\Container\Attributes\Tag;
+
+public function __construct(
+    #[Tag('reports')] protected iterable $reports,
+) {}
+```
+
+### RouteParameter
+
+```php
+use App\Models\Photo;
+use Illuminate\Container\Attributes\RouteParameter;
+
+public function __construct(
+    #[RouteParameter('photo')] protected Photo $photo,
+) {}
+```
+
+### Give
+
+```php
+use App\Contracts\UserRepository;
+use App\Repositories\DatabaseRepository;
+use Illuminate\Container\Attributes\Give;
+
+public function __construct(
+    #[Give(DatabaseRepository::class)] protected UserRepository $users,
+) {}
+```
+
+### Combined Example
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Contracts\UserRepository;
+use App\Models\Photo;
+use App\Repositories\DatabaseRepository;
+use Illuminate\Container\Attributes\Auth;
+use Illuminate\Container\Attributes\Cache;
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Container\Attributes\Context;
+use Illuminate\Container\Attributes\DB;
+use Illuminate\Container\Attributes\Give;
+use Illuminate\Container\Attributes\Log;
+use Illuminate\Container\Attributes\RouteParameter;
+use Illuminate\Container\Attributes\Tag;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Database\Connection;
+use Psr\Log\LoggerInterface;
+
+class PhotoController extends Controller
+{
+    public function __construct(
+        #[Auth('web')] protected Guard $auth,
+        #[Cache('redis')] protected Repository $cache,
+        #[Config('app.timezone')] protected string $timezone,
+        #[Context('uuid')] protected string $uuid,
+        #[Context('ulid', hidden: true)] protected string $ulid,
+        #[DB('mysql')] protected Connection $connection,
+        #[Give(DatabaseRepository::class)] protected UserRepository $users,
+        #[Log('daily')] protected LoggerInterface $log,
+        #[RouteParameter('photo')] protected Photo $photo,
+        #[Tag('reports')] protected iterable $reports,
+    ) {}
+}
+```
+
+### Custom Contextual Attributes
+
+Create an attribute class that implements `Illuminate\Contracts\Container\ContextualAttribute`:
+
+```php
+<?php
+
+namespace App\Container\Attributes;
+
+use Illuminate\Contracts\Container\ContextualAttribute;
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class StripeKey implements ContextualAttribute
+{
+    public function __construct(
+        public string $key = 'default',
+    ) {}
+}
+```
+
+Then resolve the value by implementing a resolver:
+
+```php
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\ServiceProvider;
+
+class StripeKeyResolver extends ServiceProvider
+{
+    public function register(): void
+    {
+        StripeKey::resolveUsing(function (StripeKey $attribute, Container $container) {
+            return $container->make(Config::class)->get("services.stripe.{$attribute->key}_key");
+        });
+    }
+}
+```
+
+Usage:
+
+```php
+public function __construct(
+    #[StripeKey('secret')] protected string $stripeKey,
+) {}
+```
+
+## Tagging
+
+```php
+$this->app->tag([
+    CpuReport::class,
+    MemoryReport::class,
+], 'reports');
+
+// Retrieve tagged bindings
+$this->app->tagged('reports'); // returns iterable of resolved instances
+```
+
+## Extending Bindings
+
+Decorate or replace a resolved service:
+
+```php
+$this->app->extend(Service::class, function (Service $service, Application $app) {
+    return new DecoratedService($service);
+});
+```
+
+## Resolving
+
+```php
+// From anywhere
+$api = resolve('HelpSpot\API');
+
+// From a service provider
+$api = $this->app->make('HelpSpot\API');
+
+// With additional parameters
+$api = $this->app->makeWith('HelpSpot\API', ['key' => 'abc123']);
+
+// Check if bound
+$bound = $this->app->bound('HelpSpot\API');
+
+// Helper and facade
+$api = app('HelpSpot\API');
+$api = \App::make('HelpSpot\API');
+```
+
+## Automatic Injection
+
+Type-hint dependencies in constructors and they resolve automatically. Supported locations:
+
+- Controllers
+- Jobs
+- Event listeners
+- Queue listeners
+- Middleware
+- Route closures
+- `handle()` methods of commands and jobs
+
+```php
+// Route closure
+Route::get('/users', function (UserRepository $users) {
+    return $users->all();
+});
+```
+
+## Method Invocation
+
+```php
+use App\Services\PaymentProcessor;
+use Illuminate\Support\Facades\App;
+
+$result = App::call(function (PaymentProcessor $processor) {
+    return $processor->charge(100);
+});
+
+// On an object method
+$result = App::call([$this, 'methodName']);
+```
+
+## Container Events
+
+### Resolving Events
+
+```php
+$this->app->resolving(Transistor::class, function (Transistor $transistor, Application $app) {
+    // Called when Transistor is resolved
+});
+
+$this->app->resolving(function (mixed $object, Application $app) {
+    // Called when any object is resolved
+});
+```
+
+### Rebinding Events
+
+```php
+$this->app->bind(EventPusher::class, RedisEventPusher::class);
+
+$this->app->rebinding(EventPusher::class, function (Application $app, EventPusher $newInstance) {
+    // Called whenever the binding is re-bound
+});
+
+$this->app->bind(EventPusher::class, SqsEventPusher::class);
+// Triggers the rebinding closure
+```
+
+## PSR-11
+
+The container implements `Psr\Container\ContainerInterface`:
+
+```php
+use Psr\Container\ContainerInterface;
+
+class SomeClass
+{
+    public function __construct(
+        private ContainerInterface $container,
+    ) {}
+
+    public function handle(): void
+    {
+        $service = $this->container->get(Service::class);
+    }
+}
+```
+
+## Best Practices
+
+1. **Use auto-injection whenever possible** — let the container resolve without explicit binding
+2. **Bind interfaces, not implementations** — enables swapping and testing
+3. **Use `#[Singleton]` for stateless services** — HTTP clients, parsers, configuration providers
+4. **Use `#[Scoped]` for request-scoped state** — current user, request context
+5. **Prefer contextual attributes over `when()->needs()->give()` chains** — cleaner DX
+6. **Use `#[Bind]` on interfaces** — eliminates manual provider registration
+7. **Resolve from the container only at composition roots** — avoid `resolve()` or `app()->make()` deep in business logic
+8. **Use `tag()` for collections of similar services** — report generators, payment gateways, notification channels
+9. **Use `extend()` to decorate services** — add logging, caching, or metrics without modifying the original class
+10. **Register bindings in the `register()` method of a ServiceProvider** — never in `boot()`

--- a/skills/laravel-specialist/references/events.md
+++ b/skills/laravel-specialist/references/events.md
@@ -1,0 +1,556 @@
+# Events & Listeners
+
+## Generating Events and Listeners
+
+```bash
+php artisan make:event PodcastProcessed
+php artisan make:listener SendPodcastNotification --event=PodcastProcessed
+php artisan make:event   # Interactive prompt
+php artisan make:listener # Interactive prompt
+php artisan event:list    # List registered listeners
+php artisan event:cache   # Cache listener manifest (production)
+php artisan event:clear   # Destroy event cache
+```
+
+## Defining Events
+
+```php
+<?php
+
+namespace App\Events;
+
+use App\Models\Order;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class OrderShipped
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Order $order,
+    ) {}
+}
+```
+
+## Defining Listeners
+
+```php
+<?php
+
+namespace App\Listeners;
+
+use App\Events\OrderShipped;
+
+class SendShipmentNotification
+{
+    public function __construct() {}
+
+    public function handle(OrderShipped $event): void
+    {
+        // Access the order using $event->order...
+    }
+}
+```
+
+Use union types to listen to multiple events:
+
+```php
+public function handle(PodcastProcessed|PodcastPublished $event): void
+{
+    // ...
+}
+```
+
+Stop propagation by returning `false` from `handle`.
+
+## Registering Events and Listeners
+
+### Auto-Discovery (default)
+
+Laravel auto-scans `app/Listeners/` for methods starting with `handle` or `__invoke`:
+
+```php
+class SendPodcastNotification
+{
+    public function handle(PodcastProcessed $event): void
+    {
+        // ...
+    }
+}
+```
+
+Custom discovery directories in `bootstrap/app.php`:
+
+```php
+->withEvents(discover: [
+    __DIR__.'/../app/Domain/Orders/Listeners',
+])
+
+// Wildcard for multiple directories
+->withEvents(discover: [
+    __DIR__.'/../app/Domain/*/Listeners',
+])
+```
+
+### Dynamic Discovery
+
+Control discovery at runtime with `ShouldBeDiscovered`:
+
+```php
+use Illuminate\Contracts\Events\ShouldBeDiscovered;
+
+class SendPodcastNotification implements ShouldBeDiscovered
+{
+    public function handle(PodcastProcessed $event): void
+    {
+        // ...
+    }
+
+    public static function shouldBeDiscovered(): bool
+    {
+        return app()->environment('production');
+    }
+}
+```
+
+### Manual Registration via `AppServiceProvider`
+
+```php
+use App\Domain\Orders\Events\PodcastProcessed;
+use App\Domain\Orders\Listeners\SendPodcastNotification;
+use Illuminate\Support\Facades\Event;
+
+public function boot(): void
+{
+    Event::listen(
+        PodcastProcessed::class,
+        SendPodcastNotification::class,
+    );
+}
+```
+
+### Closure Listeners
+
+```php
+use App\Events\PodcastProcessed;
+use Illuminate\Support\Facades\Event;
+
+public function boot(): void
+{
+    Event::listen(function (PodcastProcessed $event) {
+        // ...
+    });
+}
+```
+
+### Queueable Closure Listeners
+
+```php
+use function Illuminate\Events\queueable;
+
+Event::listen(queueable(function (PodcastProcessed $event) {
+    // ...
+}));
+
+// Customize connection, queue, delay
+Event::listen(queueable(function (PodcastProcessed $event) {
+    // ...
+})->onConnection('redis')->onQueue('podcasts')->delay(now()->plus(seconds: 10)));
+
+// Handle failures
+Event::listen(queueable(function (PodcastProcessed $event) {
+    // ...
+})->catch(function (PodcastProcessed $event, Throwable $e) {
+    // The queued listener failed...
+}));
+```
+
+### Wildcard Listeners
+
+```php
+Event::listen('event.*', function (string $eventName, array $data) {
+    // ...
+});
+```
+
+## Dispatching Events
+
+```php
+// Using Dispatchable trait
+OrderShipped::dispatch($order);
+
+// Using Event facade
+use Illuminate\Support\Facades\Event;
+Event::dispatch(new OrderShipped($order));
+
+// Using helper
+event(new OrderShipped($order));
+```
+
+### Dispatching After Database Transactions
+
+```php
+OrderShipped::dispatchAfterCommit($order);
+
+// Or via Event facade
+Event::dispatchAfterCommit(new OrderShipped($order));
+```
+
+### Global `after_commit` Config
+
+Set `after_commit` to `true` in `config/queue.php` per connection, or implement `ShouldQueueAfterCommit` on individual listeners.
+
+### Deferring Events
+
+```php
+use App\Events\OrderShipped;
+
+OrderShipped::dispatchIf($condition, $order);
+OrderShipped::dispatchUnless($condition, $order);
+```
+
+## Queued Event Listeners
+
+```php
+<?php
+
+namespace App\Listeners;
+
+use App\Events\OrderShipped;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendShipmentNotification implements ShouldQueue
+{
+    // ...
+}
+```
+
+### Customizing Connection, Queue & Delay (PHP 8 Attributes)
+
+```php
+use Illuminate\Queue\Attributes\Connection;
+use Illuminate\Queue\Attributes\Queue;
+use Illuminate\Queue\Attributes\Delay;
+
+#[Connection('sqs')]
+#[Queue('listeners')]
+#[Delay(60)]
+class SendShipmentNotification implements ShouldQueue
+{
+    // ...
+}
+```
+
+### Customizing at Runtime (Methods)
+
+```php
+public function viaConnection(): string
+{
+    return 'sqs';
+}
+
+public function viaQueue(): string
+{
+    return 'listeners';
+}
+
+public function withDelay(OrderShipped $event): int
+{
+    return $event->highPriority ? 0 : 60;
+}
+```
+
+### Conditional Queueing
+
+```php
+class RewardGiftCard implements ShouldQueue
+{
+    public function handle(OrderCreated $event): void
+    {
+        // ...
+    }
+
+    public function shouldQueue(OrderCreated $event): bool
+    {
+        return $event->order->subtotal >= 5000;
+    }
+}
+```
+
+### Manually Interacting With the Queue
+
+```php
+use Illuminate\Queue\InteractsWithQueue;
+
+class SendShipmentNotification implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function handle(OrderShipped $event): void
+    {
+        if ($condition) {
+            $this->release(30);
+        }
+    }
+}
+```
+
+### Database Transactions (`ShouldQueueAfterCommit`)
+
+```php
+use Illuminate\Contracts\Queue\ShouldQueueAfterCommit;
+
+class SendShipmentNotification implements ShouldQueueAfterCommit
+{
+    use InteractsWithQueue;
+}
+```
+
+### Queue Listener Middleware
+
+```php
+class SendShipmentNotification implements ShouldQueue
+{
+    public function handle(OrderShipped $event): void
+    {
+        // Process the event...
+    }
+
+    public function middleware(OrderShipped $event): array
+    {
+        return [new RateLimited];
+    }
+}
+```
+
+### Encrypted Queued Listeners
+
+```php
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+
+class SendShipmentNotification implements ShouldQueue, ShouldBeEncrypted
+{
+    // ...
+}
+```
+
+### Unique Event Listeners
+
+```php
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+
+class AcquireProductKey implements ShouldQueue, ShouldBeUnique
+{
+    public int $uniqueFor = 3600;
+
+    public function __invoke(LicenseSaved $event): void
+    {
+        // ...
+    }
+
+    public function uniqueId(LicenseSaved $event): string
+    {
+        return 'listener:'.$event->license->id;
+    }
+}
+```
+
+`ShouldBeUniqueUntilProcessing` releases the lock before processing instead of after:
+
+```php
+use Illuminate\Contracts\Queue\ShouldBeUniqueUntilProcessing;
+
+class AcquireProductKey implements ShouldQueue, ShouldBeUniqueUntilProcessing
+{
+    // ...
+}
+```
+
+Custom cache driver for unique lock:
+
+```php
+public function uniqueVia(LicenseSaved $event): Repository
+{
+    return Cache::driver('redis');
+}
+```
+
+### Handling Failed Jobs
+
+```php
+use Throwable;
+
+class SendShipmentNotification implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public function handle(OrderShipped $event): void
+    {
+        // ...
+    }
+
+    public function failed(OrderShipped $event, Throwable $exception): void
+    {
+        // ...
+    }
+}
+```
+
+### Specifying Max Attempts & Backoff (PHP 8 Attributes)
+
+```php
+use Illuminate\Queue\Attributes\Tries;
+use Illuminate\Queue\Attributes\Backoff;
+use Illuminate\Queue\Attributes\MaxExceptions;
+use Illuminate\Queue\Attributes\Timeout;
+use Illuminate\Queue\Attributes\FailOnTimeout;
+
+#[Tries(5)]
+#[Backoff(3)]
+#[MaxExceptions(3)]
+#[Timeout(120)]
+#[FailOnTimeout]
+class SendShipmentNotification implements ShouldQueue
+{
+    // ...
+}
+```
+
+### Exponential Backoff
+
+```php
+public function backoff(OrderShipped $event): array
+{
+    return [1, 5, 10]; // 1s, 5s, 10s
+}
+```
+
+### Retry Until
+
+```php
+use DateTimeInterface;
+
+public function retryUntil(): DateTimeInterface
+{
+    return now()->plus(minutes: 5);
+}
+```
+
+## Event Subscribers
+
+### Writing Subscribers
+
+```php
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Events\Dispatcher;
+
+class UserEventSubscriber
+{
+    public function handleUserLogin($event): void
+    {
+        // ...
+    }
+
+    public function handleUserLogout($event): void
+    {
+        // ...
+    }
+
+    public function subscribe(Dispatcher $events): void
+    {
+        $events->listen(
+            'Illuminate\Auth\Events\Login',
+            [self::class, 'handleUserLogin']
+        );
+
+        $events->listen(
+            'Illuminate\Auth\Events\Logout',
+            [self::class, 'handleUserLogout']
+        );
+    }
+}
+```
+
+### Registering Subscribers
+
+```php
+use App\Listeners\UserEventSubscriber;
+use Illuminate\Support\Facades\Event;
+
+public function boot(): void
+{
+    Event::subscribe(UserEventSubscriber::class);
+}
+```
+
+## Testing
+
+### Fake Events
+
+```php
+use App\Events\OrderShipped;
+use Illuminate\Support\Facades\Event;
+
+// Fake all events
+Event::fake();
+
+// Fake specific events
+Event::fake([OrderShipped::class]);
+
+// Assert event was dispatched
+Event::assertDispatched(OrderShipped::class);
+Event::assertDispatched(OrderShipped::class, fn ($event) => $event->order->id === 1);
+Event::assertDispatchedTimes(OrderShipped::class, 3);
+Event::assertNotDispatched(OrderShipped::class);
+Event::assertNothingDispatched();
+```
+
+### Faking a Subset of Events
+
+```php
+Event::fakeExcept([
+    OrderShipped::class,
+]);
+
+Event::fakeExcept([
+    'App\Events\*',
+]);
+```
+
+### Scoped Event Fakes
+
+```php
+Event::fake()->scoped();
+```
+
+Equivalent to faking all events but restoring real event dispatching at the end of the test lifecycle.
+
+## Artisan Commands
+
+| Command | Description |
+|---------|-------------|
+| `php artisan make:event` | Create a new event class (interactive without name) |
+| `php artisan make:listener` | Create a new listener class (interactive without name) |
+| `php artisan make:listener --event=EventName` | Create a listener for a specific event |
+| `php artisan event:list` | List all registered event listeners |
+| `php artisan event:cache` | Cache event listener manifest |
+| `php artisan event:clear` | Clear cached event listeners |
+| `php artisan optimize` | Cache routes, views, and events |
+
+## Best Practices
+
+1. **Keep event classes as data containers** — No business logic, just properties
+2. **Use `ShouldQueue` for slow operations** — Email, HTTP calls, file generation
+3. **Prefer auto-discovery** — Let Laravel scan `app/Listeners/` automatically
+4. **Use `dispatchAfterCommit` for transactional safety** — Ensures data is persisted before listeners run
+5. **Name events in past tense** — `OrderShipped`, `UserRegistered`, `PaymentReceived`
+6. **Use PHP 8 attributes for queue config** — Cleaner than methods for static config
+7. **Leverage `ShouldBeUnique` for idempotency** — Prevent duplicate processing
+8. **Use Event Subscribers for related events** — Group login/logout, CRUD lifecycle
+9. **Always fake events in feature tests** — Prevent accidental side effects
+10. **Handle failures with `failed()` method** — Log and notify, never silently swallow

--- a/skills/laravel-specialist/references/fortify.md
+++ b/skills/laravel-specialist/references/fortify.md
@@ -1,0 +1,487 @@
+# Laravel Fortify
+
+## What is Fortify?
+
+Frontend-agnostic authentication backend. Registers routes and controllers for login, registration, password reset, email verification, two-factor auth, and passkeys. No UI included — pair it with your own frontend.
+
+## When to Use It
+
+- You need auth backend but want a custom frontend (Blade, Vue, React, etc.)
+- Do **not** use if you're already using a starter kit (Laravel Breeze, Jetstream) — those ship with Fortify built-in
+- Not competing with Sanctum: Fortify handles registration/reset/etc., Sanctum handles token management and session auth
+
+## Installation
+
+```bash
+composer require laravel/fortify
+php artisan fortify:install
+php artisan migrate
+```
+
+`fortify:install` publishes:
+- `app/Actions/Fortify/*` — `CreateNewUser`, `ResetUserPassword`, `UpdateUserPassword`, `UpdateUserProfileInformation`
+- `app/Providers/FortifyServiceProvider.php`
+- `config/fortify.php`
+- Database migrations
+
+## Bootstrap / App Config
+
+Laravel 13.x uses `bootstrap/app.php` for service registration. Enable Fortify routing:
+
+```php
+<?php
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__ . '/../routes/web.php',
+        api: __DIR__ . '/../routes/api.php',
+        commands: __DIR__ . '/../routes/console.php',
+        health: '/up',
+        fortify: true, // enables Fortify routes
+    )
+    ->withFortify() // registers FortifyServiceProvider
+    ->create();
+```
+
+## Features Configuration
+
+```php
+<?php
+
+// config/fortify.php
+use Laravel\Fortify\Features;
+
+'features' => [
+    Features::registration(),
+    Features::resetPasswords(),
+    Features::emailVerification(),
+    Features::updateProfileInformation(),
+    Features::updatePasswords(),
+    Features::twoFactorAuthentication([
+        'confirm' => true,
+        'confirmPassword' => true,
+    ]),
+    Features::passkeys([
+        'confirmPassword' => true,
+    ]),
+],
+```
+
+## Disabling Views
+
+For SPAs or custom API frontends, set `views` to `false`:
+
+```php
+<?php
+
+// config/fortify.php
+'views' => false,
+```
+
+If using password reset with views disabled, still define a named route `password.reset` (used by the `ResetPassword` notification to generate reset URLs).
+
+## View Customization
+
+All view rendering is configured in `FortifyServiceProvider::boot()`:
+
+```php
+<?php
+
+use Laravel\Fortify\Fortify;
+
+public function boot(): void
+{
+    Fortify::loginView(fn () => view('auth.login'));
+    Fortify::registerView(fn () => view('auth.register'));
+    Fortify::requestPasswordResetLinkView(fn () => view('auth.forgot-password'));
+    Fortify::resetPasswordView(fn (Request $request) => view('auth.reset-password', ['request' => $request]));
+    Fortify::verifyEmailView(fn () => view('auth.verify-email'));
+    Fortify::twoFactorChallengeView(fn () => view('auth.two-factor-challenge'));
+    Fortify::confirmPasswordView(fn () => view('auth.confirm-password'));
+}
+```
+
+## Authentication
+
+### Login Endpoint
+
+`POST /login` — expects `email` (or username field matching `fortify.username` config) and `password`. Optional boolean `remember`.
+
+- Success: redirect to `fortify.home` URI (or 200 for XHR)
+- Failure: redirect back with validation errors (or 422 for XHR)
+
+### Customizing User Authentication
+
+```php
+<?php
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Fortify\Fortify;
+
+Fortify::authenticateUsing(function (Request $request) {
+    $user = User::where('email', $request->email)->first();
+
+    if ($user && Hash::check($request->password, $user->password)) {
+        return $user;
+    }
+});
+```
+
+### Customizing the Authentication Pipeline
+
+```php
+<?php
+
+use Laravel\Fortify\Actions\AttemptToAuthenticate;
+use Laravel\Fortify\Actions\CanonicalizeUsername;
+use Laravel\Fortify\Actions\EnsureLoginIsNotThrottled;
+use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
+use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Features;
+use Laravel\Fortify\Fortify;
+use Illuminate\Http\Request;
+
+Fortify::authenticateThrough(function (Request $request) {
+    return array_filter([
+        config('fortify.limiters.login') ? null : EnsureLoginIsNotThrottled::class,
+        config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,
+        Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
+        AttemptToAuthenticate::class,
+        PrepareAuthenticatedSession::class,
+    ]);
+});
+```
+
+### Authentication Guard
+
+Customize via `config/fortify.php` `guard` key. Defaults to `web`. For SPA auth, use `web` guard with Laravel Sanctum.
+
+### Customizing Redirects
+
+Override response contracts via service container binding in `FortifyServiceProvider::register()`:
+
+```php
+<?php
+
+use Laravel\Fortify\Contracts\LogoutResponse;
+
+$this->app->instance(LogoutResponse::class, new class implements LogoutResponse {
+    public function toResponse($request)
+    {
+        return redirect('/');
+    }
+});
+```
+
+Available contracts:
+- `LoginResponse`
+- `LogoutResponse`
+- `RegisterResponse`
+- `PasswordResetResponse`
+- `TwoFactorLoginResponse`
+- `LockoutResponse`
+
+## Two-Factor Authentication
+
+### User Model Setup
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Fortify\TwoFactorAuthenticatable;
+
+class User extends Authenticatable
+{
+    use Notifiable, TwoFactorAuthenticatable;
+}
+```
+
+### Enabling
+
+`POST /user/two-factor-authentication` — triggers password confirmation. Sets session `status = two-factor-authentication-enabled`.
+
+### Confirming
+
+Display QR code:
+
+```php
+$request->user()->twoFactorQrCodeSvg();
+```
+
+Display recovery codes:
+
+```php
+(array) $request->user()->recoveryCodes();
+```
+
+`POST /user/confirmed-two-factor-authentication` — expects `code`. Sets `status = two-factor-authentication-confirmed`.
+
+### Authenticating
+
+`GET /two-factor-challenge` — returns view. `POST /two-factor-challenge` — expects `code` (TOTP) or `recovery_code`.
+
+- Success: redirect to `fortify.home` (204 for XHR)
+- Failure: redirect back with errors (422 for XHR)
+
+XHR login response includes `two_factor` boolean — redirect to challenge screen when `true`.
+
+### Disabling
+
+`DELETE /user/two-factor-authentication`
+
+### Regenerating Recovery Codes
+
+`POST /user/two-factor-recovery-codes`
+
+## Passkeys (WebAuthn)
+
+### User Model Setup
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Fortify\Contracts\PasskeyUser;
+use Laravel\Fortify\PasskeyAuthenticatable;
+
+class User extends Authenticatable implements PasskeyUser
+{
+    use Notifiable, PasskeyAuthenticatable;
+}
+```
+
+### Passkeys Configuration
+
+```php
+<?php
+
+// config/fortify.php
+'passkeys' => [
+    'relying_party_id' => parse_url(config('app.url'), PHP_URL_HOST),
+    'allowed_origins' => [config('app.url')],
+    'user_handle_secret' => config('app.key'),
+    'timeout' => 60000,
+],
+```
+
+### JavaScript Client
+
+```bash
+npm install @laravel/passkeys
+```
+
+```js
+import { Passkeys } from "@laravel/passkeys";
+
+await Passkeys.register({ name: "MacBook Pro" });
+await Passkeys.verify();
+```
+
+Also available for React (`@laravel/passkeys/react`), Vue (`@laravel/passkeys/vue`), and Svelte (`@laravel/passkeys/svelte`).
+
+### Authentication Flow
+
+1. `GET /passkeys/login/options` — returns WebAuthn challenge
+2. Pass to `navigator.credentials.get(...)` on the frontend
+3. `POST /passkeys/login` — send credential + optional `remember`
+
+### Confirming Password With Passkeys
+
+1. `GET /passkeys/confirm/options`
+2. `POST /passkeys/confirm` — sends credential
+
+### Registering Passkeys
+
+1. `GET /user/passkeys/options`
+2. `POST /user/passkeys` — sends `name` + `credential`
+
+### Deleting Passkeys
+
+`DELETE /user/passkeys/{passkey}`
+
+## Registration
+
+`POST /register` — expects `name`, email/username, `password`, `password_confirmation`.
+
+- Success: redirect to `fortify.home` (201 for XHR)
+- Failure: redirect back with errors (422 for XHR)
+
+### Customizing Registration
+
+Modify `app/Actions/Fortify/CreateNewUser.php` — contains validation rules and user creation logic.
+
+```php
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Fortify\Contracts\CreatesNewUsers;
+
+class CreateNewUser implements CreatesNewUsers
+{
+    use PasswordValidationRules;
+
+    public function create(array $input): User
+    {
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => $this->passwordRules(),
+        ])->validate();
+
+        return User::create([
+            'name' => $input['name'],
+            'email' => $input['email'],
+            'password' => Hash::make($input['password']),
+        ]);
+    }
+}
+```
+
+Override the action class:
+
+```php
+<?php
+
+use App\Actions\Fortify\CreateNewUser;
+
+Fortify::createUsersUsing(CreateNewUser::class);
+```
+
+## Password Reset
+
+### Request Reset Link
+
+`POST /forgot-password` — expects `email`.
+
+- Success: redirect back with `status` session variable
+- Failure: redirect back with errors (422 for XHR)
+
+### Reset Password
+
+`POST /reset-password` — expects `email`, `password`, `password_confirmation`, `token` (from route param).
+
+- Success: redirect to `/login` with `status`
+- Failure: redirect back with errors (422 for XHR)
+
+### Customizing Password Resets
+
+Modify `app/Actions/Fortify/ResetUserPassword.php`:
+
+```php
+<?php
+
+use Laravel\Fortify\Contracts\ResetsUserPasswords;
+
+Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
+```
+
+## Email Verification
+
+Requires `MustVerifyEmail` interface on User model + `emailVerification` feature enabled.
+
+- `POST /email/verification-notification` — resends verification link. Sets `status = verification-link-sent`.
+- Protect routes with `verified` middleware:
+
+```php
+<?php
+
+Route::get('/dashboard', function () {
+    // ...
+})->middleware(['verified']);
+```
+
+## Profile / Password Update
+
+```php
+<?php
+
+// Update profile info
+Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
+
+// Update password
+Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
+```
+
+Modify the corresponding action classes in `app/Actions/Fortify/`.
+
+## Rate Limiting
+
+Configure limiters in `config/fortify.php`:
+
+```php
+<?php
+
+'limiters' => [
+    'login' => 'login',
+    'two-factor' => 'two-factor',
+    'passkeys' => 'passkeys',
+],
+```
+
+Define the actual limiter in `AppServiceProvider` or a `RouteServiceProvider`:
+
+```php
+<?php
+
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+
+RateLimiter::for('login', function (Request $request) {
+    $email = (string) $request->email;
+
+    return Limit::perMinute(5)->by($email . $request->ip());
+});
+```
+
+## Testing
+
+```php
+<?php
+
+use App\Models\User;
+use Laravel\Fortify\Fortify;
+use Illuminate\Support\Facades\Hash;
+
+// Custom auth logic in tests
+Fortify::authenticateUsing(function (Request $request) {
+    $user = User::where('email', $request->email)->first();
+
+    return $user && Hash::check($request->password, $user->password) ? $user : null;
+});
+
+// Test registration
+$response = $this->post('/register', [
+    'name' => 'Test User',
+    'email' => 'test@example.com',
+    'password' => 'password',
+    'password_confirmation' => 'password',
+]);
+
+$response->assertRedirect('/home');
+$this->assertAuthenticated();
+```
+
+## Best Practices
+
+- Set `'views' => false` for SPAs or API-driven frontends
+- Disable features you don't use in `config/fortify.php` to reduce route surface
+- Customize via `FortifyServiceProvider` — keep logic centralized
+- Use `Fortify::authenticateUsing()` for non-standard auth (LDAP, OTP, etc.)
+- Override response contracts instead of modifying vendor code
+- Rate-limit login, 2FA, and passkey endpoints
+- Use `Features::passkeys()` with `confirmPassword: true` for security
+- Pair with Sanctum for SPA+API setups where Fortify handles auth initiation and Sanctum handles session/token persistence

--- a/skills/laravel-specialist/references/helpers.md
+++ b/skills/laravel-specialist/references/helpers.md
@@ -1,0 +1,969 @@
+# Helpers
+
+## Arrays & Objects
+
+All methods in this section are available on `Illuminate\Support\Arr`. The global helpers `data_get`, `data_set`, `data_fill`, `head`, and `last` are also listed.
+
+### Arr::accessible
+
+```php
+use Illuminate\Support\Arr;
+
+Arr::accessible(['a', 'b']); // true
+Arr::accessible('string');   // false
+Arr::accessible(new stdClass); // false
+```
+
+### Arr::add
+
+```php
+$array = Arr::add(['name' => 'John'], 'age', 30);
+// ['name' => 'John', 'age' => 30]
+
+// No-op if key already exists
+$array = Arr::add(['name' => 'John'], 'name', 'Jane');
+// ['name' => 'John']
+```
+
+### Arr::collapse
+
+```php
+$array = Arr::collapse([[1, 2], [3, 4], [5]]);
+// [1, 2, 3, 4, 5]
+```
+
+### Arr::crossJoin
+
+```php
+$result = Arr::crossJoin([1, 2], ['a', 'b']);
+// [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
+```
+
+### Arr::dot
+
+```php
+$array = ['user' => ['name' => 'John', 'profile' => ['age' => 30]]];
+$dotted = Arr::dot($array);
+// ['user.name' => 'John', 'user.profile.age' => 30]
+```
+
+### Arr::except
+
+```php
+$array = ['name' => 'John', 'age' => 30, 'role' => 'admin'];
+$filtered = Arr::except($array, ['role']);
+// ['name' => 'John', 'age' => 30]
+```
+
+### Arr::first
+
+```php
+$array = [100, 200, 300];
+$first = Arr::first($array, fn (int $value) => $value >= 200);
+// 200
+
+$first = Arr::first($array, fn (int $value) => $value > 500, 0);
+// 0 (default)
+```
+
+### Arr::flatten
+
+```php
+$array = Arr::flatten([1, [2, [3, [4]]]]);
+// [1, 2, 3, 4]
+
+$array = Arr::flatten([1, [2, [3, [4]]]], depth: 2);
+// [1, 2, 3, [4]]
+```
+
+### Arr::forget
+
+```php
+$array = ['products' => ['desk' => ['price' => 100]]];
+Arr::forget($array, 'products.desk');
+// ['products' => []]
+```
+
+### Arr::get
+
+```php
+$array = ['products' => ['desk' => ['price' => 100]]];
+Arr::get($array, 'products.desk.price');  // 100
+Arr::get($array, 'products.desk.discount', 0); // 0
+Arr::get($array, 'products.desk.discount', fn () => 0); // 0
+```
+
+### Arr::has
+
+```php
+$array = ['product' => ['name' => 'Desk', 'price' => 100]];
+Arr::has($array, 'product.name');      // true
+Arr::has($array, ['product.name', 'product.price']); // true
+Arr::has($array, 'product.discount');  // false
+```
+
+### Arr::isAssoc
+
+```php
+Arr::isAssoc(['a', 'b']);          // false (list)
+Arr::isAssoc(['a' => 1, 'b' => 2]); // true (associative)
+```
+
+### Arr::isList
+
+```php
+Arr::isList(['a', 'b']);            // true
+Arr::isAssoc(['a' => 1, 'b' => 2]); // false
+```
+
+### Arr::join
+
+```php
+Arr::join(['a', 'b', 'c'], ', ');        // 'a, b, c'
+Arr::join(['a', 'b', 'c'], ', ', ' and '); // 'a, b and c'
+```
+
+### Arr::keyBy
+
+```php
+$array = [
+    ['id' => 1, 'name' => 'John'],
+    ['id' => 2, 'name' => 'Jane'],
+];
+$keyed = Arr::keyBy($array, 'id');
+// [1 => ['id' => 1, 'name' => 'John'], 2 => ['id' => 2, 'name' => 'Jane']]
+```
+
+### Arr::last
+
+```php
+$array = [100, 200, 300];
+$last = Arr::last($array, fn (int $value) => $value < 300);
+// 200
+
+$last = Arr::last($array, fn (int $value) => $value > 500, 0);
+// 0 (default)
+```
+
+### Arr::map
+
+```php
+$array = Arr::map([1, 2, 3], fn (int $value) => $value * 2);
+// [2, 4, 6]
+```
+
+### Arr::mapSpread
+
+```php
+$array = [[1, 2], [3, 4]];
+$result = Arr::mapSpread($array, fn (int $a, int $b) => $a + $b);
+// [3, 7]
+```
+
+### Arr::mapWithKeys
+
+```php
+$array = [
+    ['id' => 1, 'name' => 'John'],
+    ['id' => 2, 'name' => 'Jane'],
+];
+$mapped = Arr::mapWithKeys($array, fn (array $item) => [$item['id'] => $item['name']]);
+// [1 => 'John', 2 => 'Jane']
+```
+
+### Arr::only
+
+```php
+$array = ['name' => 'John', 'age' => 30, 'role' => 'admin'];
+$filtered = Arr::only($array, ['name', 'role']);
+// ['name' => 'John', 'role' => 'admin']
+```
+
+### Arr::pluck
+
+```php
+$array = [
+    ['id' => 1, 'name' => 'John'],
+    ['id' => 2, 'name' => 'Jane'],
+];
+Arr::pluck($array, 'name'); // ['John', 'Jane']
+
+// With keys
+Arr::pluck($array, 'name', 'id'); // [1 => 'John', 2 => 'Jane']
+
+// Dot notation
+$array = [['user' => ['name' => 'John']]];
+Arr::pluck($array, 'user.name'); // ['John']
+```
+
+### Arr::prepend
+
+```php
+$array = Arr::prepend([1, 2, 3], 0);
+// [0, 1, 2, 3]
+
+$array = Arr::prepend(['name' => 'John'], 'admin', 'role');
+// ['role' => 'admin', 'name' => 'John']
+```
+
+### Arr::pull
+
+```php
+$array = ['name' => 'John', 'age' => 30];
+$name = Arr::pull($array, 'name');
+// $name = 'John', $array = ['age' => 30]
+```
+
+### Arr::query
+
+```php
+$array = Arr::query(['name' => 'John', 'role' => 'admin']);
+// 'name=John&role=admin'
+```
+
+### Arr::random
+
+```php
+$array = Arr::random([1, 2, 3, 4]);  // Random single value
+$items = Arr::random([1, 2, 3, 4], 2); // Random 2 values
+```
+
+### Arr::set
+
+```php
+$array = ['products' => ['desk' => ['price' => 100]]];
+Arr::set($array, 'products.desk.price', 200);
+// ['products' => ['desk' => ['price' => 200]]]
+```
+
+### Arr::shuffle
+
+```php
+$shuffled = Arr::shuffle([1, 2, 3, 4]);
+// Random order
+```
+
+### Arr::sort
+
+```php
+$sorted = Arr::sort(['Desk', 'Table', 'Chair']);
+// ['Chair', 'Desk', 'Table']
+
+$sorted = Arr::sort([
+    ['name' => 'Desk'],
+    ['name' => 'Table'],
+], fn (array $value) => $value['name']);
+// [['name' => 'Desk'], ['name' => 'Table']]
+```
+
+### Arr::sortDesc
+
+```php
+$sorted = Arr::sortDesc(['Desk', 'Table', 'Chair']);
+// ['Table', 'Desk', 'Chair']
+```
+
+### Arr::take
+
+```php
+$taken = Arr::take([1, 2, 3, 4], 2);
+// [1, 2]
+
+$taken = Arr::take([1, 2, 3, 4], -2);
+// [3, 4]
+```
+
+### Arr::toCssClasses
+
+```php
+$isActive = false;
+$hasError = true;
+
+Arr::toCssClasses(['p-4', 'font-bold' => $isActive, 'bg-red' => $hasError]);
+// 'p-4 bg-red'
+```
+
+### Arr::toCssStyles
+
+```php
+$hasColor = true;
+
+Arr::toCssStyles(['background-color: blue', 'color: blue' => $hasColor]);
+// 'background-color: blue; color: blue;'
+```
+
+### Arr::where
+
+```php
+$filtered = Arr::where([1, 2, 3, 4], fn (int $value) => $value > 2);
+// [2 => 3, 3 => 4] (keeps keys)
+```
+
+### Arr::wrap
+
+```php
+Arr::wrap('John');         // ['John']
+Arr::wrap(['John']);       // ['John']
+Arr::wrap(null);           // []
+```
+
+### data_get
+
+```php
+$data = ['user' => ['profile' => ['age' => 30]]];
+data_get($data, 'user.profile.age');  // 30
+data_get($data, 'user.profile.age', 0); // 30
+
+// Supports wildcards
+$data = [['name' => 'John'], ['name' => 'Jane']];
+data_get($data, '*.name'); // ['John', 'Jane']
+```
+
+### data_set
+
+```php
+$data = ['products' => ['desk' => ['price' => 100]]];
+data_set($data, 'products.desk.price', 200);
+// ['products' => ['desk' => ['price' => 200]]]
+
+// Wildcard
+$data = [['name' => 'Desk'], ['name' => 'Table']];
+data_set($data, '*.price', 50);
+
+// With overwrite: false — does not overwrite existing values
+data_set($data, 'products.desk.price', 200, overwrite: false);
+```
+
+### data_fill
+
+```php
+$data = ['products' => ['desk' => ['price' => 100]]];
+data_fill($data, 'products.desk.discount', 0);
+// ['products' => ['desk' => ['price' => 100, 'discount' => 0]]]
+
+// No-op if key already exists
+data_fill($data, 'products.desk.price', 200);
+// ['products' => ['desk' => ['price' => 100]]]
+```
+
+### head
+
+```php
+head([1, 2, 3]); // 1
+```
+
+### last
+
+```php
+last([1, 2, 3]); // 3
+```
+
+## Numbers
+
+All number helpers are available on `Illuminate\Support\Number`.
+
+### Number::format
+
+```php
+use Illuminate\Support\Number;
+
+Number::format(1000);          // '1,000'
+Number::format(1000.5, precision: 2); // '1,000.50'
+Number::format(1000, locale: 'de');   // '1.000'
+```
+
+### Number::currency
+
+```php
+Number::currency(1000);                      // '$1,000.00'
+Number::currency(1000, in: 'EUR');           // '€1,000.00'
+Number::currency(1000, in: 'EUR', locale: 'de'); // '1.000,00 €'
+Number::currency(1000, precision: 0);        // '$1,000'
+```
+
+### Number::abbreviate
+
+```php
+Number::abbreviate(1000);            // '1K'
+Number::abbreviate(489939);          // '490K'
+Number::abbreviate(1230000, precision: 2); // '1.23M'
+```
+
+### Number::fileSize
+
+```php
+Number::fileSize(1024);            // '1 KB'
+Number::fileSize(1024 * 1024);     // '1 MB'
+Number::fileSize(1500);            // '1 KB'
+Number::fileSize(1500, precision: 2); // '1.46 KB'
+```
+
+### Number::forHumans
+
+```php
+Number::forHumans(1000);     // '1 thousand'
+Number::forHumans(1000000);  // '1 million'
+Number::forHumans(1234567);  // '1 million'
+```
+
+### Number::ordinal
+
+```php
+Number::ordinal(1);   // '1st'
+Number::ordinal(2);   // '2nd'
+Number::ordinal(3);   // '3rd'
+Number::ordinal(21);  // '21st'
+Number::ordinal(12);  // '12th'
+```
+
+### Number::percentage
+
+```php
+Number::percentage(10);           // '10%'
+Number::percentage(10.123, precision: 2); // '10.12%'
+Number::percentage(10, locale: 'de');     // '10 %'
+```
+
+### Number::spell
+
+```php
+Number::spell(102);                     // 'one hundred and two'
+Number::spell(88, locale: 'fr');        // 'quatre-vingt-huit'
+Number::spell(10, after: 10);           // '10' (not spelled if <= after)
+Number::spell(11, after: 10);           // 'eleven'
+Number::spell(5, until: 10);            // 'five' (spelled if <= until)
+Number::spell(10, until: 10);           // '10' (not spelled)
+```
+
+### Number::clamp
+
+```php
+Number::clamp(105, min: 10, max: 100); // 100
+Number::clamp(5, min: 10, max: 100);   // 10
+Number::clamp(50, min: 10, max: 100);  // 50
+```
+
+## Paths
+
+```php
+app_path('Models/User.php');       // /app/Models/User.php
+base_path('vendor/autoload.php');  // /vendor/autoload.php
+config_path('app.php');            // /config/app.php
+database_path('migrations');       // /database/migrations
+lang_path('en/messages.php');      // /lang/en/messages.php
+public_path('css/app.css');        // /public/css/app.css
+resource_path('views/welcome.blade.php'); // /resources/views/welcome.blade.php
+storage_path('app/public');        // /storage/app/public
+```
+
+## URLs
+
+```php
+// Generate URL for a named route
+$url = route('users.show', ['user' => 1]);
+$url = route('users.show', ['user' => 1], absolute: false);
+
+// Generate URL to a controller action
+$url = action([UserController::class, 'show'], ['user' => 1]);
+
+// Redirect to a named route
+return to_route('users.show', ['user' => 1]);
+
+// Redirect to a controller action
+return to_action([UserController::class, 'show'], ['user' => 1]);
+
+// Asset URLs
+asset('css/app.css');           // http://example.com/css/app.css
+secure_asset('css/app.css');    // https://example.com/css/app.css
+
+// Current URL with or without scheme
+url('/users');                  // http://example.com/users
+secure_url('/users');           // https://example.com/users
+
+// Force HTTPS scheme in generated URLs
+URL::forceScheme('https');
+```
+
+## Miscellaneous
+
+### abort / abort_if
+
+```php
+abort(404);
+abort_if(! $user, 403, 'Unauthorized');
+abort_unless($user, 401, 'Please login');
+```
+
+### app
+
+```php
+$container = app();
+$service = app('HelpSpot\API');
+$service = app()->make('HelpSpot\API');
+$version = app()->version();
+$inProduction = app()->environment('production');
+```
+
+### auth
+
+```php
+$user = auth()->user();
+$id = auth()->id();
+auth()->login($user);
+auth()->logout();
+```
+
+### back
+
+```php
+return back(); // Redirect to previous page
+return back()->with('status', 'Saved!');
+```
+
+### bcrypt
+
+```php
+$hash = bcrypt('plain-text-password');
+```
+
+### blank / filled
+
+```php
+blank('');       // true
+blank('test');   // false
+blank([]);       // true
+
+filled('test');  // true
+filled('');      // false
+```
+
+### broadcast
+
+```php
+broadcast(new OrderShipped($order));
+broadcast(new OrderShipped($order))->toOthers();
+```
+
+### cache
+
+```php
+cache(['key' => 'value'], 300);   // Store for 5 minutes
+$value = cache('key');            // Retrieve
+cache()->put('key', 'value', 300); // Store via facade
+```
+
+### collect
+
+```php
+$collection = collect([1, 2, 3]);
+$collection = collect(['name' => 'John']);
+```
+
+### config
+
+```php
+$timezone = config('app.timezone');
+$timezone = config('app.timezone', 'UTC');
+config(['app.timezone' => 'America/New_York']);
+```
+
+### cookie
+
+```php
+$value = cookie('name');
+$response = new Response('Hello World');
+$response->withCookie(cookie('name', 'value', 120));
+```
+
+### csrf_field / csrf_token
+
+```php
+csrf_field();  // '<input type="hidden" name="_token" value="abc123">'
+csrf_token();  // 'abc123'
+```
+
+### dd / dump
+
+```php
+dd($variable);           // Dump and die
+dd($var1, $var2, $var3); // Multiple values
+
+dump($variable);         // Dump without dying
+```
+
+### decrypt / encrypt
+
+```php
+$encrypted = encrypt('sensitive-data');
+$decrypted = decrypt($encrypted);
+```
+
+### dispatch / dispatch_sync
+
+```php
+dispatch(new ProcessPodcast($podcast)); // Queue job
+dispatch_sync(new ProcessPodcast($podcast)); // Run synchronously
+ProcessPodcast::dispatch($podcast);    // Via trait
+```
+
+### env
+
+```php
+$key = env('APP_KEY');
+$debug = env('APP_DEBUG', false);
+```
+> **Note:** Use `config()` in production. Only use `env()` in config files.
+
+### event
+
+```php
+event(new OrderShipped($order));
+```
+
+### info / logger
+
+```php
+info('User logged in', ['id' => $userId]);
+logger('Something happened');
+logger()->error('Failed to process', ['order' => $orderId]);
+```
+
+### method_field
+
+```php
+method_field('PUT');
+// '<input type="hidden" name="_method" value="PUT">'
+```
+
+### now / today
+
+```php
+now();           // Carbon\Carbon instance
+today();         // Carbon\Carbon instance at 00:00:00
+now()->addDay();
+today()->subMonth();
+```
+
+### old
+
+```php
+$name = old('name');
+$email = old('email', 'default@example.com');
+```
+
+### once
+
+```php
+// Cache the result for the duration of the request
+$exp = once(fn () => expensiveComputation());
+// Subsequent calls return the cached result
+```
+
+### optional
+
+```php
+optional($user?->profile)->bio;
+// Returns null if $user->profile is null, no error
+```
+
+### policy
+
+```php
+if (policy($post, 'update', $user)) {
+    // User can update
+}
+```
+
+### redirect
+
+```php
+return redirect('/home');
+return redirect()->route('users.show', ['user' => 1]);
+return redirect()->action([UserController::class, 'index']);
+return redirect()->away('https://example.com');
+return redirect()->back()->withInput();
+```
+
+### report
+
+```php
+report($exception); // Log exception via the exception handler
+```
+
+### request
+
+```php
+$name = request('name');
+$all = request()->all();
+$user = request()->user();
+$isApi = request()->expectsJson();
+```
+
+### rescue
+
+```php
+$result = rescue(fn () => riskyOperation(), 'fallback');
+$result = rescue(fn () => riskyOperation(), fn () => 'fallback');
+```
+
+### resolve
+
+```php
+$service = resolve(Service::class);
+$service = resolve('HelpSpot\API', ['key' => 'abc']);
+```
+
+### response
+
+```php
+return response('Hello', 200);
+return response()->json(['user' => $user]);
+return response()->json(['error' => 'Not found'], 404);
+return response()->download($pathToFile);
+return response()->streamDownload(function () {
+    echo file_get_contents($pathToFile);
+}, 'export.csv');
+```
+
+### retry
+
+```php
+$result = retry(3, function () {
+    return unstableApiCall();
+}, 100); // 100ms between attempts
+
+$result = retry(3, function (int $attempt) {
+    return unstableApiCall();
+}, function (int $attempt) {
+    return $attempt * 100; // Dynamic backoff
+});
+```
+
+### session
+
+```php
+session(['key' => 'value']);
+$value = session('key');
+$value = session('key', 'default');
+session()->flash('status', 'Task successful');
+```
+
+### tap
+
+```php
+$user = tap(User::find(1), function (User $user) {
+    $user->update(['name' => 'Updated']);
+    $user->save();
+});
+// Returns the User instance regardless of what the closure returns
+```
+
+### throw_if / throw_unless
+
+```php
+throw_if(! $user, \App\Exceptions\UserNotFoundException::class);
+throw_unless($user, \App\Exceptions\UserNotFoundException::class);
+```
+
+### transform
+
+```php
+transform($value, fn (string $value) => ucfirst($value));
+// Returns transformed value if not blank, else null
+
+$value = transform($value, fn (string $v) => ucfirst($v), 'default');
+```
+
+### validator
+
+```php
+$validator = validator($request->all(), [
+    'email' => 'required|email',
+    'name' => 'required|string|max:255',
+]);
+
+if ($validator->fails()) {
+    // Handle
+}
+```
+
+### value
+
+```php
+$greeting = value(fn () => 'Hello World'); // Evaluates the closure
+value('Hello'); // Returns 'Hello' (pass-through for non-closures)
+```
+
+### view
+
+```php
+return view('profile.show', ['user' => $user]);
+$html = view('emails.welcome', ['user' => $user])->render();
+```
+
+### when
+
+```php
+$value = when(true, fn () => 'first', fn () => 'second');
+// 'first'
+
+$value = when(false, fn () => 'first', fn () => 'second');
+// 'second'
+```
+
+### with
+
+```php
+$user = with(User::find(1), function (User $user) {
+    $user->load('posts');
+    return $user;
+});
+
+// Single expression version
+$user = with(User::find(1)); // Just returns the value
+```
+
+## Other Utilities
+
+### Benchmark
+
+```php
+use Illuminate\Support\Benchmark;
+
+// Single callback
+Benchmark::dd(fn () => User::find(1)); // 0.1 ms
+
+// Compare scenarios
+Benchmark::dd([
+    'Scenario 1' => fn () => User::count(),
+    'Scenario 2' => fn () => User::all()->count(),
+]);
+
+// Return without dumping
+$time = Benchmark::measure(fn () => User::find(1));
+// 0.1
+
+$times = Benchmark::measure([
+    'with_redis' => fn () => cache('key'),
+    'without' => fn () => DB::table('cache')->first(),
+]);
+// ['with_redis' => 0.5, 'without' => 3.2]
+
+// Warm up specific return type
+$result = Benchmark::value(fn () => User::count());
+// Returns the actual value, not the time
+```
+
+### Lottery
+
+```php
+use Illuminate\Support\Lottery;
+
+Lottery::odds(1, 100)->winner(fn () => $user->win())
+    ->loser(fn () => $user->lose())
+    ->choose();
+
+// As a class
+class ReportCpuJob implements ShouldQueue
+{
+    use Dispatchable;
+
+    public function __construct()
+    {
+        // Runs in 1 out of 100 jobs
+    }
+
+    public static function shouldDispatch(): Lottery
+    {
+        return Lottery::odds(1, 100);
+    }
+}
+```
+
+### Pipeline
+
+```php
+use Illuminate\Pipeline\Pipeline;
+
+$result = app(Pipeline::class)
+    ->send($request)
+    ->through([
+        EnsureTokenIsValid::class,
+        EnsureUserIsSubscribed::class,
+        SetLocale::class,
+    ])
+    ->then(fn ($request) => (new HomeController)->index($request));
+
+// Each pipe is a class with handle($request, $next) method
+```
+
+### Sleep
+
+```php
+use Illuminate\Support\Sleep;
+
+Sleep::for(1.5)->minutes();
+Sleep::for(2)->seconds();
+Sleep::for(500)->milliseconds();
+Sleep::for(5000)->microseconds();
+Sleep::until(now()->addMinute());
+Sleep::sleep(2);           // PHP sleep alias
+Sleep::usleep(5000);       // PHP usleep alias
+
+// Return value after sleeping
+$result = Sleep::for(1)->second()->then(fn () => 1 + 1);
+
+// Sleep while condition is true
+Sleep::for(1)->second()->while(fn () => shouldKeepSleeping());
+```
+
+### Timebox
+
+```php
+use Illuminate\Support\Timebox;
+
+$result = (new Timebox)->call(function () {
+    // Run at most 5 seconds
+    return $this->process();
+}, 5);
+
+// With early return
+$result = (new Timebox)->call(function ($timebox) {
+    if ($this->shouldReturnEarly()) {
+        $timebox->returnEarly();
+    }
+    return $this->process();
+}, 5);
+```
+
+### URI
+
+```php
+use Illuminate\Support\Uri;
+
+$uri = Uri::of('https://laravel.com/docs')
+    ->withQuery(['page' => 2, 'search' => 'eloquent']);
+
+// 'https://laravel.com/docs?page=2&search=eloquent'
+
+$uri = Uri::of('https://laravel.com')
+    ->withPath('/docs')
+    ->withFragment('installation');
+
+// 'https://laravel.com/docs#installation'
+
+$uri = Uri::of('https://laravel.com/docs/11.x')
+    ->replacePath('/docs/12.x');
+
+// 'https://laravel.com/docs/12.x'
+
+// Retrieve parsed components
+Uri::of('https://user@laravel.com:8080/docs?q=eloquent#first')
+    ->scheme();   // 'https'
+    ->user();     // 'user'
+    ->host();     // 'laravel.com'
+    ->port();     // 8080
+    ->path();     // '/docs'
+    ->query();    // 'q=eloquent'
+    ->fragment(); // 'first'
+```

--- a/skills/laravel-specialist/references/inertia.md
+++ b/skills/laravel-specialist/references/inertia.md
@@ -1,0 +1,311 @@
+# Inertia.js
+
+## Overview
+
+Inertia bridges Laravel with React, Vue, or Svelte — you write routes/controllers in Laravel, return page components, and Inertia handles the SPA experience without building a separate API.
+
+Single codebase, server-side routing, client-side rendering.
+
+## Installation
+
+```bash
+composer require inertiajs/inertia-laravel
+php artisan inertia:middleware
+```
+
+Register the middleware in `bootstrap/app.php`:
+
+```php
+<?php
+
+use App\Http\Middleware\HandleInertiaRequests;
+
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->web(append: [
+        HandleInertiaRequests::class,
+    ]);
+})
+```
+
+Install the client-side adapter:
+
+```bash
+npm install @inertiajs/react   # or @inertiajs/vue3, @inertiajs/svelte
+```
+
+Set up your app entry point to use Inertia:
+
+```js
+import { createInertiaApp } from '@inertiajs/react'
+import { createRoot } from 'react-dom/client'
+
+createInertiaApp({
+    resolve: name => import(`./pages/${name}.jsx`),
+    setup({ el, App, props }) {
+        createRoot(el).render(<App {...props} />)
+    },
+})
+```
+
+## Root Template
+
+The root Blade template renders the initial HTML and mounts the JS app. Located at `resources/views/app.blade.php` by default:
+
+```blade
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    @vite('resources/js/app.jsx')
+    @inertiaHead
+</head>
+<body>
+    @inertia
+</body>
+</html>
+```
+
+Configure the root template in the middleware:
+
+```php
+<?php
+
+// app/Http/Middleware/HandleInertiaRequests.php
+protected $rootView = 'app';
+```
+
+## Rendering Pages
+
+```php
+<?php
+
+use Inertia\Inertia;
+
+class EventsController extends Controller
+{
+    public function show(Event $event): \Inertia\Response
+    {
+        return Inertia::render('Event/Show', [
+            'event'   => $event->only('id', 'title', 'start_date'),
+            'canEdit' => auth()->user()->can('edit', $event),
+        ]);
+    }
+}
+```
+
+The prop value can be any of:
+- Primitives, arrays, collections, Eloquent models, API resources
+- Closures (lazy — resolved only when rendered)
+- `Inertia::optional(fn () => ...)` — never sent unless requested via partial reload
+- `Inertia::always(...)` — always included, even in partial reloads
+
+### Blade-Only View Data
+
+Pass data available only in the root Blade template, not exposed to JS:
+
+```php
+<?php
+
+return Inertia::render('Event/Edit', ['event' => $event])
+    ->withViewData(['meta' => $event->meta]);
+```
+
+```blade
+<meta name="description" content="{{ $meta }}">
+```
+
+## Shared Data
+
+Configure in `HandleInertiaRequests` middleware:
+
+```php
+<?php
+
+namespace App\Http\Middleware;
+
+use Inertia\Middleware;
+use Illuminate\Http\Request;
+
+class HandleInertiaRequests extends Middleware
+{
+    public function share(Request $request): array
+    {
+        return array_merge(parent::share($request), [
+            'app.name' => config('app.name'),
+            'auth.user' => fn () => $request->user()
+                ? $request->user()->only('id', 'name', 'email')
+                : null,
+            'flash' => [
+                'message' => fn () => $request->session()->get('message'),
+            ],
+        ]);
+    }
+
+    // Resolved once and cached client-side across navigations
+    public function shareOnce(Request $request): array
+    {
+        return array_merge(parent::shareOnce($request), [
+            'countries' => fn () => Country::all(),
+        ]);
+    }
+}
+```
+
+## Asset Versioning
+
+Prevents stale JS/CSS after deployment. Configure in the middleware:
+
+```php
+<?php
+
+public function version(Request $request): ?string
+{
+    return parent::version($request);
+}
+```
+
+By default, uses `md5_file` on the Vite manifest. You can override with a custom version string.
+
+When assets change, the server returns `409 Conflict` with `X-Inertia-Location` header, forcing a full page reload.
+
+## Forms & Validation
+
+### Server-side
+
+```php
+<?php
+
+class UsersController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'first_name' => ['required', 'max:50'],
+            'last_name'  => ['required', 'max:50'],
+            'email'      => ['required', 'email'],
+        ]);
+
+        User::create($validated);
+
+        return to_route('users.index');
+    }
+}
+```
+
+Inertia automatically sends validation errors back as props. Access them client-side:
+
+```jsx
+import { useForm } from '@inertiajs/react'
+
+const { data, setData, post, errors } = useForm({
+    first_name: '',
+    last_name: '',
+    email: '',
+})
+
+const submit = (e) => {
+    e.preventDefault()
+    post('/users')
+}
+
+return (
+    <form onSubmit={submit}>
+        <input value={data.first_name} onChange={e => setData('first_name', e.target.value)} />
+        {errors.first_name && <div>{errors.first_name}</div>}
+        <button type="submit">Save</button>
+    </form>
+)
+```
+
+## Redirects
+
+```php
+<?php
+
+// Standard redirect (Inertia handles it as a client-side visit)
+return redirect('/dashboard');
+return to_route('dashboard');
+
+// External redirect (full page load, breaks out of Inertia)
+return Inertia::location('https://example.com');
+
+// Back with flash
+return back()->with('message', 'User created!');
+```
+
+## Responses
+
+Inertia responses use specific HTTP codes:
+- `200` — successful GET
+- `201` — successful POST/PUT
+- `204` — successful DELETE
+- `303` — redirect after POST/PUT/PATCH (session preservation)
+- `409` — asset version mismatch (forces full reload)
+- `422` — validation errors
+
+## Testing
+
+```php
+<?php
+
+// Page assertions
+$response = $this->get('/events/1');
+
+$response->assertInertia(fn ($page) => $page
+    ->component('Event/Show')
+    ->has('event')
+    ->where('event.id', 1)
+    ->has('canEdit')
+);
+
+// Flash data assertions on redirects
+$response = $this->post('/users', [
+    'first_name' => 'John',
+    'last_name'  => 'Doe',
+    'email'      => 'john@example.com',
+]);
+
+$response->assertRedirect('/dashboard')
+    ->assertInertiaFlash('message')
+    ->assertInertiaFlash('message', 'User created!')
+    ->assertInertiaFlash('notification.type', 'success')
+    ->assertInertiaFlashMissing('error');
+
+// Version assertion
+$response->assertInertiaHasVersion('abc123');
+```
+
+Available helpers on `assertInertia`:
+- `->component(string)` — matches page component name
+- `->has(string\|int, ?\Closure)` — prop exists or nested assertion
+- `->where(string, mixed)` — exact prop value
+- `->whereAll(array)` — multiple exact values
+- `->missing(string)` — prop absent
+- `->count(string, int)` — array length
+- `->dd()` / `->dump()` — debug
+
+## Partial Reloads
+
+Request only specific props to reduce payload. Use the `only` option:
+
+```jsx
+import { Link } from '@inertiajs/react'
+
+<Link href="/users?active=true" only={['users']}>
+    Show active
+</Link>
+```
+
+Server-side props marked as `Inertia::optional()` are only sent when explicitly requested via partial reload.
+
+## Best Practices
+
+- Set up shared data for auth user, flash messages, and app config in `HandleInertiaRequests`
+- Use lazy closures (`fn () => ...`) for expensive or optional data
+- Use `Inertia::always()` for props that must survive partial reloads (e.g. flash messages)
+- Use `Inertia::optional()` for heavy data only needed on full-page visits
+- Return `303` redirects after form submissions to prevent double-submit
+- Keep page components lean — move complex logic into dedicated components
+- Use `@inertiaHead` in your root template for per-page `<head>` management
+- Version assets via the middleware `version()` method or rely on Vite's built-in hashing

--- a/skills/laravel-specialist/references/notifications.md
+++ b/skills/laravel-specialist/references/notifications.md
@@ -1,0 +1,648 @@
+# Notifications
+
+## Generating Notifications
+
+```bash
+php artisan make:notification PostPublished
+```
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class PostPublished extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly Post $post
+    ) {}
+}
+```
+
+## Sending Notifications
+
+```php
+<?php
+
+use App\Models\User;
+use App\Notifications\PostPublished;
+use Illuminate\Support\Facades\Notification;
+
+// Using the Notifiable trait
+$user->notify(new PostPublished($post));
+
+// Using the Notification facade
+Notification::send($users, new PostPublished($post));
+
+// Send immediately (not queued)
+Notification::sendNow($users, new PostPublished($post));
+```
+
+## Defining Channels (via Method)
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PostPublished extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly Post $post
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'broadcast'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $url = route('posts.show', $this->post);
+
+        return (new MailMessage)
+            ->greeting('Hello!')
+            ->line('Your post has been published.')
+            ->action('View Post', $url)
+            ->line('Thank you for using our application!');
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'post_id' => $this->post->id,
+            'post_title' => $this->post->title,
+            'message' => "Your post \"{$this->post->title}\" has been published.",
+        ];
+    }
+
+    public function toBroadcast(object $notifiable): BroadcastMessage
+    {
+        return new BroadcastMessage([
+            'post_id' => $this->post->id,
+            'post_title' => $this->post->title,
+        ]);
+    }
+}
+```
+
+## Queueing Notifications
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class PostPublished extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly Post $post
+    ) {
+        $this->delay(now()->addMinutes(5));
+    }
+}
+
+// At send time
+$user->notify((new PostPublished($post))->delay(now()->addMinutes(10)));
+
+// Specify connection and queue
+$user->notify((new PostPublished($post))
+    ->onConnection('redis')
+    ->onQueue('notifications'));
+```
+
+## On-Demand Notifications
+
+```php
+<?php
+
+use App\Notifications\InvoicePaid;
+use Illuminate\Support\Facades\Notification;
+
+Notification::route('mail', 'guest@example.com')
+    ->route('vonage', '15556667777')
+    ->route('slack', '#notifications')
+    ->notify(new InvoicePaid($invoice));
+
+// Custom routing
+Notification::routes(function ($notifiable) {
+    $notifiable->route('mail', $this->email);
+    $notifiable->route('vonage', $this->phone);
+})->notify(new InvoicePaid($invoice));
+```
+
+## Mail Notifications
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class InvoicePaid extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $url = route('invoices.show', $this->invoice);
+
+        return (new MailMessage)
+            ->greeting('Hi '.$notifiable->name.',')
+            ->line('Your invoice has been paid successfully.')
+            ->lineIf($this->invoice->discount > 0, "You saved \${$this->invoice->discount}!")
+            ->action('View Invoice', $url)
+            ->line('Thank you for your business!');
+    }
+}
+```
+
+### MailMessage with Error Style
+
+```php
+return (new MailMessage)
+    ->error()
+    ->subject('Payment Failed')
+    ->greeting('Oops!')
+    ->line('Your payment could not be processed.')
+    ->action('Try Again', $url);
+```
+
+### Markdown Mail
+
+```php
+return (new MailMessage)
+    ->subject('Post Published')
+    ->markdown('emails.post-published', [
+        'post' => $this->post,
+        'url' => $url,
+    ]);
+```
+
+## Database Notifications
+
+```bash
+php artisan notifications:table
+php artisan migrate
+```
+
+```php
+public function via(object $notifiable): array
+{
+    return ['database'];
+}
+
+public function toDatabase(object $notifiable): array
+{
+    return [
+        'post_id' => $this->post->id,
+        'type' => 'post_published',
+        'message' => "Your post \"{$this->post->title}\" was published.",
+    ];
+}
+```
+
+### Accessing Notifications
+
+```php
+<?php
+
+use App\Models\User;
+
+$user = User::find(1);
+
+// All notifications
+$notifications = $user->notifications;
+
+// Unread notifications
+$unread = $user->unreadNotifications;
+
+// Marking as read
+$user->unreadNotifications->markAsRead();
+
+// Using the specific model
+$notification = $user->notifications()->first();
+$notification->markAsRead();
+
+// Delete notification
+$notification->delete();
+```
+
+```php
+// routes/api.php
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/notifications', function (Request $request) {
+        return $request->user()->notifications()->paginate(20);
+    });
+
+    Route::get('/notifications/unread', function (Request $request) {
+        return $request->user()->unreadNotifications;
+    });
+
+    Route::post('/notifications/{notification}/read', function (Request $request, $notification) {
+        $request->user()->notifications()
+            ->where('id', $notification)
+            ->firstOrFail()
+            ->markAsRead();
+
+        return response()->noContent();
+    });
+
+    Route::post('/notifications/mark-all-read', function (Request $request) {
+        $request->user()->unreadNotifications->markAsRead();
+
+        return response()->noContent();
+    });
+});
+```
+
+## Broadcast Notifications
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\BroadcastMessage;
+use Illuminate\Notifications\Notification;
+
+class PostPublished extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['broadcast'];
+    }
+
+    public function toBroadcast(object $notifiable): BroadcastMessage
+    {
+        return new BroadcastMessage([
+            'post_id' => $this->post->id,
+            'title' => $this->post->title,
+            'excerpt' => $this->post->excerpt,
+        ]);
+    }
+
+    public function broadcastType(): string
+    {
+        return 'post.published';
+    }
+}
+```
+
+### Listening with Echo
+
+```typescript
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+
+window.Echo = new Echo({
+    broadcaster: 'pusher',
+    key: import.meta.env.VITE_PUSHER_APP_KEY,
+    cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER,
+});
+
+window.Echo.private(`App.Models.User.${userId}`)
+    .notification((notification) => {
+        console.log(notification.title);
+    });
+```
+
+## SMS / Vonage Notifications
+
+```bash
+composer require laravel/vonage-notification-channel
+```
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\VonageMessage;
+use Illuminate\Notifications\Notification;
+
+class OrderShipped extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['vonage'];
+    }
+
+    public function toVonage(object $notifiable): VonageMessage
+    {
+        return (new VonageMessage)
+            ->content('Your order has shipped! Tracking: ABC123')
+            ->from('15556667777')
+            ->unicode();
+    }
+}
+```
+
+## Slack Notifications
+
+```bash
+composer require laravel/slack-notification-channel
+```
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class DeploymentSucceeded extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return ['slack'];
+    }
+
+    public function toSlack(object $notifiable): SlackMessage
+    {
+        return (new SlackMessage)
+            ->success()
+            ->content('Deployment succeeded!')
+            ->attachment(function ($attachment) {
+                $attachment->title('Deployment #42', 'https://deploy.example.com/42')
+                    ->fields([
+                        'Environment' => 'Production',
+                        'Branch' => 'main',
+                        'Commit' => 'a1b2c3d',
+                        'Duration' => '2m 34s',
+                    ]);
+            });
+    }
+}
+```
+
+### Slack with Interactivity
+
+```php
+return (new SlackMessage)
+    ->warning()
+    ->content('Deployment requires approval.')
+    ->attachment(function ($attachment) {
+        $attachment
+            ->title('Deployment #43', 'https://deploy.example.com/43')
+            ->fields([
+                'Environment' => 'Production',
+                'Requester' => 'Jane Doe',
+            ])
+            ->actions([
+                actionButton('Approve', 'https://deploy.example.com/43/approve'),
+                actionButton('Reject', 'https://deploy.example.com/43/reject'),
+            ]);
+    });
+```
+
+## Custom Channels
+
+```php
+<?php
+
+namespace App\Notifications\Channels;
+
+use App\Models\User;
+use RuntimeException;
+
+class SmsChannel
+{
+    public function send(object $notifiable, Notification $notification): void
+    {
+        $message = $notification->toSms($notifiable);
+
+        $phone = $notifiable->phone_number;
+
+        if (empty($phone)) {
+            throw new RuntimeException('No phone number found.');
+        }
+
+        // Send SMS via external provider
+        SmsProvider::send($phone, $message);
+    }
+}
+```
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use App\Notifications\Channels\SmsChannel;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class OrderConfirmed extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function via(object $notifiable): array
+    {
+        return [SmsChannel::class, 'mail'];
+    }
+
+    public function toSms(object $notifiable): string
+    {
+        return "Order #{$this->order->id} confirmed!";
+    }
+}
+```
+
+## Testing
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\PostPublished;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class PostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_post_published_sends_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $post = Post::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($user)->post("/posts/{$post->id}/publish");
+
+        Notification::assertSentTo(
+            $user,
+            PostPublished::class,
+            function ($notification, $channels) use ($post) {
+                return $notification->post->id === $post->id;
+            }
+        );
+    }
+
+    public function test_notification_is_not_sent_on_draft(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post('/posts', [
+            'title' => 'Draft',
+            'content' => 'Not published yet.',
+        ]);
+
+        Notification::assertNotSentTo($user, PostPublished::class);
+    }
+
+    public function test_notification_sent_to_specific_users(): void
+    {
+        Notification::fake();
+
+        $users = User::factory()->count(3)->create();
+        $post = Post::factory()->create();
+
+        $this->actingAs($users[0])->post("/posts/{$post->id}/publish");
+
+        Notification::assertSentTo($users[0], PostPublished::class);
+        Notification::assertNotSentTo($users[1], PostPublished::class);
+        Notification::assertNotSentTo($users[2], PostPublished::class);
+    }
+
+    public function test_notification_count(): void
+    {
+        Notification::fake();
+
+        $users = User::factory()->count(2)->create();
+
+        Notification::assertNothingSent();
+
+        $this->actingAs($users[0])->post('/posts', [
+            'title' => 'Test',
+            'content' => 'Content',
+        ]);
+
+        Notification::assertCount(1);
+    }
+
+    public function test_on_demand_notification(): void
+    {
+        Notification::fake();
+
+        Notification::route('mail', 'test@example.com')
+            ->notify(new PostPublished(Post::factory()->create()));
+
+        Notification::assertSentTo(
+            Notification::route('mail', 'test@example.com'),
+            PostPublished::class
+        );
+    }
+}
+```
+
+## PHP 8 Attributes
+
+```php
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Post;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Attributes\MaxExceptions;
+use Illuminate\Notifications\Attributes\Tries;
+use Illuminate\Notifications\Notification;
+
+#[Tries(3)]
+#[MaxExceptions(5)]
+class PostPublished extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly Post $post
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'mail-queue',
+            'database' => 'default',
+        ];
+    }
+}
+
+// Inline alternative
+(new PostPublished($post))->tries(5);
+```
+
+## Best Practices
+
+1. **Always implement ShouldQueue** - Keep notification sending out of the request lifecycle
+2. **Use specific channels per use case** - Email for critical, database for in-app, broadcast for real-time
+3. **Keep toMail/toDatabase clean** - Delegate complex view logic to Mailables or markdown templates
+4. **Use on-demand for ad-hoc** - Send notifications to non-user recipients via `Notification::route()`
+5. **Mark database notifications as read** - Let users see unread counts and dismiss notifications
+6. **Use broadcastType()** - Define custom broadcast event types for frontend routing
+7. **Avoid heavy logic in notifications** - Notifications are data carriers, not business logic containers
+8. **Set queue and connection explicitly** - Route notification channels to appropriate queues
+9. **Test notification assertions** - Use `Notification::fake()` and `assertSentTo` in feature tests
+10. **Use `#[Tries]` / `#[MaxExceptions]`** - Configure retry behavior on queued notifications

--- a/skills/laravel-specialist/references/packages.md
+++ b/skills/laravel-specialist/references/packages.md
@@ -1,0 +1,351 @@
+# Package Development
+
+## Overview
+
+Packages are the primary way to add functionality to Laravel. This guide covers Laravel-specific packages with routes, controllers, views, and configuration.
+
+## Package Discovery
+
+Auto-register service providers and facades via `composer.json`:
+
+```json
+{
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Barryvdh\\Debugbar\\ServiceProvider"
+            ],
+            "aliases": {
+                "Debugbar": "Barryvdh\\Debugbar\\Facade"
+            }
+        }
+    }
+}
+```
+
+### Opting Out of Discovery
+
+In the application's `composer.json`:
+
+```json
+{
+    "extra": {
+        "laravel": {
+            "dont-discover": [
+                "barryvdh/laravel-debugbar"
+            ]
+        }
+    }
+}
+```
+
+Disable for all packages:
+
+```json
+"dont-discover": ["*"]
+```
+
+## Service Providers
+
+Extend `Illuminate\Support\ServiceProvider`. Two methods: `register` and `boot`.
+
+```php
+<?php
+
+namespace Vendor\Package;
+
+use Illuminate\Support\ServiceProvider;
+
+class PackageServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // Bind into container, merge config
+    }
+
+    public function boot(): void
+    {
+        // Load routes, views, migrations, etc.
+    }
+}
+```
+
+## Resources
+
+### Configuration
+
+Publish config files:
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->publishes([
+        __DIR__.'/../config/courier.php' => config_path('courier.php'),
+    ]);
+}
+```
+
+Merge default config (in `register` method):
+
+```php
+<?php
+
+public function register(): void
+{
+    $this->mergeConfigFrom(
+        __DIR__.'/../config/courier.php', 'courier'
+    );
+}
+```
+
+Only merges the first level of the array. Users access config via `config('courier.option')`.
+
+Do **not** use closures in config files — they cannot be serialized by `config:cache`.
+
+### Routes
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+}
+```
+
+Respects route caching automatically.
+
+### Migrations
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->publishesMigrations([
+        __DIR__.'/../database/migrations' => database_path('migrations'),
+    ]);
+}
+```
+
+Laravel auto-updates migration timestamps when publishing.
+
+### Language Files
+
+Load translations:
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->loadTranslationsFrom(__DIR__.'/../lang', 'courier');
+}
+```
+
+Usage: `trans('courier::messages.welcome')`.
+
+JSON translations:
+
+```php
+<?php
+
+$this->loadJsonTranslationsFrom(__DIR__.'/../lang');
+```
+
+Publishing language files:
+
+```php
+<?php
+
+$this->publishes([
+    __DIR__.'/../lang' => $this->app->langPath('vendor/courier'),
+]);
+```
+
+### Views
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->loadViewsFrom(__DIR__.'/../resources/views', 'courier');
+}
+```
+
+Usage: `view('courier::dashboard')`.
+
+Override in app by placing views in `resources/views/vendor/courier/`.
+
+Publishing views:
+
+```php
+<?php
+
+$this->publishes([
+    __DIR__.'/../resources/views' => resource_path('views/vendor/courier'),
+]);
+```
+
+### View Components
+
+Register a named component:
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Blade;
+use VendorPackage\View\Components\AlertComponent;
+
+public function boot(): void
+{
+    Blade::component('package-alert', AlertComponent::class);
+}
+```
+
+Usage: `<x-package-alert />`.
+
+Autoload with component namespace:
+
+```php
+<?php
+
+Blade::componentNamespace('Nightshade\\Views\\Components', 'nightshade');
+```
+
+Usage: `<x-nightshade::calendar />`, `<x-nightshade::color-picker />`.
+
+Anonymous components: place in a `components` subdirectory of your package's views directory. Render with `<x-courier::alert />`.
+
+### "About" Artisan Command
+
+Add info to `php artisan about`:
+
+```php
+<?php
+
+use Illuminate\Foundation\Console\AboutCommand;
+
+public function boot(): void
+{
+    AboutCommand::add('My Package', fn () => ['Version' => '1.0.0']);
+}
+```
+
+## Commands
+
+```php
+<?php
+
+use Courier\Console\Commands\InstallCommand;
+use Courier\Console\Commands\NetworkCommand;
+
+public function boot(): void
+{
+    if ($this->app->runningInConsole()) {
+        $this->commands([
+            InstallCommand::class,
+            NetworkCommand::class,
+        ]);
+    }
+}
+```
+
+### Optimize Commands
+
+Register commands that run during `optimize` / `optimize:clear`:
+
+```php
+<?php
+
+public function boot(): void
+{
+    if ($this->app->runningInConsole()) {
+        $this->optimizes(
+            optimize: 'package:optimize',
+            clear: 'package:clear-optimizations',
+        );
+    }
+}
+```
+
+### Reload Commands
+
+Register commands that run during `reload`:
+
+```php
+<?php
+
+public function boot(): void
+{
+    if ($this->app->runningInConsole()) {
+        $this->reloads('package:reload');
+    }
+}
+```
+
+## Public Assets
+
+Publish JS, CSS, images to `public/vendor/{package}`:
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->publishes([
+        __DIR__.'/../public' => public_path('vendor/courier'),
+    ], 'public');
+}
+```
+
+Users publish with `--force` flag to overwrite on updates:
+
+```bash
+php artisan vendor:publish --tag=public --force
+```
+
+## Publishing File Groups
+
+Tag publish groups for selective publishing:
+
+```php
+<?php
+
+public function boot(): void
+{
+    $this->publishes([
+        __DIR__.'/../config/package.php' => config_path('package.php'),
+    ], 'courier-config');
+
+    $this->publishesMigrations([
+        __DIR__.'/../database/migrations/' => database_path('migrations'),
+    ], 'courier-migrations');
+}
+```
+
+Users publish by tag:
+
+```bash
+php artisan vendor:publish --tag=courier-config
+php artisan vendor:publish --tag=courier-migrations
+```
+
+Or by provider:
+
+```bash
+php artisan vendor:publish --provider="Vendor\Package\PackageServiceProvider"
+```
+
+## Best Practices
+
+- Use `mergeConfigFrom` in `register()` for defaults, `publishes` in `boot()` for overrides
+- Guard command registration with `$this->app->runningInConsole()`
+- Use `publishesMigrations()` instead of `publishes()` for migrations
+- Prefix translation and view namespaces with your package name
+- Use `optimizes()` to hook into Laravel's deploy optimization commands
+- Use `AboutCommand::add()` to expose package version and config summary
+- Test your package with [Orchestral Testbench](https://github.com/orchestral/testbench)

--- a/skills/laravel-specialist/references/sanctum.md
+++ b/skills/laravel-specialist/references/sanctum.md
@@ -1,0 +1,376 @@
+# Sanctum Authentication
+
+## Installation
+
+```bash
+php artisan install:api
+```
+
+This publishes the `config/sanctum.php` config file and creates the `api` routes file. The migration for `personal_access_tokens` is also published.
+
+## User Model Setup
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Sanctum\HasApiTokens;
+
+class User extends Authenticatable
+{
+    use HasApiTokens;
+
+    // ...
+}
+```
+
+## Issuing API Tokens
+
+```php
+$token = $user->createToken('token-name');
+
+return $token->plainTextToken;
+
+// Abilities (permissions)
+$token = $user->createToken('token-name', ['post:create', 'post:read']);
+
+// Token with expiration
+use DateTimeImmutable;
+
+$expiresAt = new DateTimeImmutable('+30 days');
+$token = $user->createToken('token-name', ['*'], $expiresAt);
+
+return $token->plainTextToken;
+```
+
+## Checking Token Abilities
+
+```php
+if ($user->tokenCan('post:create')) {
+    // The user's token has the post:create ability
+}
+
+if ($user->tokenCant('post:delete')) {
+    // The user's token does not have the post:delete ability
+}
+```
+
+## Protecting Routes
+
+```php
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/user', function (Request $request) {
+        return $request->user();
+    });
+
+    Route::apiResource('posts', PostController::class);
+});
+```
+
+## Ability Middleware
+
+```php
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/orders', function () {
+        // Token has the orders:read ability
+    })->middleware(['abilities:orders:read']);
+
+    Route::post('/orders', function () {
+        // Token has the orders:create ability
+    })->middleware(['abilities:orders:create']);
+});
+
+// You can also use the can middleware with policies
+Route::put('/posts/{post}', function (Post $post) {
+    // Token must have the ability AND pass the policy
+})->middleware(['auth:sanctum', 'can:update,post']);
+```
+
+## Revoking Tokens
+
+```php
+// Revoke all tokens for the user
+$user->tokens()->delete();
+
+// Revoke the current token
+$user->currentAccessToken()->delete();
+
+// Revoke a specific token by ID
+$user->tokens()->where('id', $tokenId)->delete();
+```
+
+## Token Expiration
+
+```php
+// config/sanctum.php
+'expiration' => 60 * 24, // Tokens expire after 24 hours (in minutes)
+// Set to null for tokens that never expire
+```
+
+```bash
+# Prune expired tokens from the database
+php artisan sanctum:prune-expired
+
+# Prune expired tokens older than 24 hours
+php artisan sanctum:prune-expired --hours=24
+```
+
+Expiration via `createToken`:
+
+```php
+use Carbon\CarbonImmutable;
+
+$token = $user->createToken(
+    'token-name',
+    ['*'],
+    CarbonImmutable::now()->addDays(7)
+);
+```
+
+## SPA Authentication
+
+```php
+// config/sanctum.php
+'stateful' => [
+    'localhost:3000',
+    'localhost:5173',
+    'your-app.test',
+],
+```
+
+```php
+// bootstrap/app.php
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        api: __DIR__.'/../routes/api.php',
+        // ...
+    )
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->statefulApi();
+    })
+    // ...
+    ->create();
+```
+
+CSRF protection for SPA login:
+
+```php
+// From your SPA, make a GET request to /sanctum/csrf-cookie
+await axios.get('/sanctum/csrf-cookie');
+
+// Then make the login request
+await axios.post('/login', {
+    email: 'user@example.com',
+    password: 'password',
+});
+```
+
+Session-based SPA login:
+
+```php
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class LoginController
+{
+    public function store(Request $request): Response
+    {
+        $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $user = User::where('email', $request->email)->first();
+
+        if (!$user || !Hash::check($request->password, $user->password)) {
+            return response()->json([
+                'message' => 'The provided credentials are incorrect.',
+            ], 401);
+        }
+
+        auth()->login($user);
+
+        return response()->noContent();
+    }
+
+    public function destroy(Request $request): Response
+    {
+        auth('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response()->noContent();
+    }
+}
+```
+
+## Mobile API Authentication
+
+```php
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class LoginController
+{
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+            'device_name' => ['required', 'string'],
+        ]);
+
+        $user = User::where('email', $request->email)->first();
+
+        if (!$user || !Hash::check($request->password, $user->password)) {
+            return response()->json([
+                'message' => 'The provided credentials are incorrect.',
+            ], 401);
+        }
+
+        $token = $user->createToken($request->device_name, ['*'])->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => $user,
+        ]);
+    }
+
+    public function destroy(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(['message' => 'Logged out successfully.']);
+    }
+}
+```
+
+## Testing
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class PostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_create_posts(): void
+    {
+        $user = User::factory()->create();
+
+        Sanctum::actingAs($user, ['post:create']);
+
+        $response = $this->postJson('/api/posts', [
+            'title' => 'Test Post',
+            'content' => 'Content here.',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_user_without_ability_cannot_create(): void
+    {
+        $user = User::factory()->create();
+
+        Sanctum::actingAs($user, ['post:read']);
+
+        $response = $this->postJson('/api/posts', [
+            'title' => 'Test Post',
+            'content' => 'Content here.',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_unauthenticated_user_cannot_access(): void
+    {
+        $response = $this->postJson('/api/posts', [
+            'title' => 'Test Post',
+            'content' => 'Content here.',
+        ]);
+
+        $response->assertStatus(401);
+    }
+}
+```
+
+## Middleware Registration
+
+```php
+// bootstrap/app.php
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withMiddleware(function (Middleware $middleware) {
+        // Enable SPA stateful authentication
+        $middleware->statefulApi();
+
+        // Register ability middleware alias
+        $middleware->alias([
+            'abilities' => \Laravel\Sanctum\Http\Middleware\CheckAbilities::class,
+            'ability' => \Laravel\Sanctum\Http\Middleware\CheckForAnyAbility::class,
+        ]);
+    })
+    ->create();
+```
+
+## CORS Configuration
+
+```php
+// config/cors.php
+return [
+    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'allowed_methods' => ['*'],
+    'allowed_origins' => [env('FRONTEND_URL', 'http://localhost:3000')],
+    'allowed_origins_patterns' => [],
+    'allowed_headers' => ['*'],
+    'exposed_headers' => [],
+    'max_age' => 0,
+    'supports_credentials' => true,
+];
+```
+
+For SPA authentication, `supports_credentials` must be `true` and the `allowed_origins` must match your frontend domain exactly.
+
+## Best Practices
+
+1. **Use token abilities** - Scope tokens with fine-grained permissions like `post:create`, `post:read`
+2. **Regenerate tokens on password change** - Invalidate old sessions when security changes
+3. **Use short-lived tokens for mobile** - Combine with refresh token pattern for long sessions
+4. **Store `plainTextToken` only once** - Return it on creation; it cannot be retrieved later
+5. **Always validate abilities in middleware** - Not just in the controller
+6. **Use SPA auth for first-party clients** - Avoid token management on the frontend
+7. **Prune expired tokens regularly** - Schedule `sanctum:prune-expired` in the console kernel
+8. **Unique device names** - Use device_name or UUID to identify tokens for users managing multiple sessions
+9. **Never expose `plainTextToken` in logs** - Sanitize token values in log context
+10. **Use HTTPS in production** - Always encrypt token transmission

--- a/skills/laravel-specialist/references/socialite.md
+++ b/skills/laravel-specialist/references/socialite.md
@@ -1,0 +1,240 @@
+# Laravel Socialite
+
+## Overview
+
+OAuth 1.0 & 2.0 authentication provider. Supports Facebook, X, LinkedIn, Google, GitHub, GitLab, Bitbucket, and Slack. Community adapters at [socialiteproviders.com](https://socialiteproviders.com/).
+
+## Installation
+
+```bash
+composer require laravel/socialite
+```
+
+## Configuration
+
+Add credentials to `config/services.php`:
+
+```php
+<?php
+
+'github' => [
+    'client_id' => env('GITHUB_CLIENT_ID'),
+    'client_secret' => env('GITHUB_CLIENT_SECRET'),
+    'redirect' => 'http://example.com/callback-url',
+],
+```
+
+Provider keys: `facebook`, `x`, `linkedin-openid`, `google`, `github`, `gitlab`, `bitbucket`, `slack`, `slack-openid`.
+
+Relative `redirect` paths are resolved to full URLs automatically.
+
+## Authentication
+
+### Routing
+
+Two routes: one to redirect, one to handle the callback:
+
+```php
+<?php
+
+use Laravel\Socialite\Socialite;
+
+Route::get('/auth/redirect', function () {
+    return Socialite::driver('github')->redirect();
+});
+
+Route::get('/auth/callback', function () {
+    $user = Socialite::driver('github')->user();
+
+    // $user->token
+});
+```
+
+### Authentication and Storage
+
+```php
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Socialite\Socialite;
+
+Route::get('/auth/callback', function () {
+    $githubUser = Socialite::driver('github')->user();
+
+    $user = User::updateOrCreate([
+        'github_id' => $githubUser->id,
+    ], [
+        'name' => $githubUser->name,
+        'email' => $githubUser->email,
+        'github_token' => $githubUser->token,
+        'github_refresh_token' => $githubUser->refreshToken,
+    ]);
+
+    Auth::login($user);
+
+    return redirect('/dashboard');
+});
+```
+
+### Access Scopes
+
+```php
+<?php
+
+// Merge scopes with existing
+return Socialite::driver('github')
+    ->scopes(['read:user', 'public_repo'])
+    ->redirect();
+
+// Overwrite all scopes
+return Socialite::driver('github')
+    ->setScopes(['read:user', 'public_repo'])
+    ->redirect();
+```
+
+### Slack Bot Scopes
+
+Slack has two token types: Bot (`xoxb-`) and User (`xoxp-`). Use `asBotUser()` for bot tokens (e.g. sending notifications to workspaces):
+
+```php
+<?php
+
+// Redirect for bot token
+return Socialite::driver('slack')
+    ->asBotUser()
+    ->setScopes(['chat:write', 'chat:write.public', 'chat:write.customize'])
+    ->redirect();
+
+// In callback, fetch user as bot
+$user = Socialite::driver('slack')->asBotUser()->user();
+```
+
+When using bot tokens, only `$user->token` is hydrated.
+
+### Optional Parameters
+
+```php
+<?php
+
+return Socialite::driver('google')
+    ->with(['hd' => 'example.com'])
+    ->redirect();
+```
+
+Avoid reserved keywords: `state`, `response_type`.
+
+## Retrieving User Details
+
+```php
+<?php
+
+$user = Socialite::driver('github')->user();
+
+// OAuth 2.0
+$token = $user->token;
+$refreshToken = $user->refreshToken;
+$expiresIn = $user->expiresIn;
+
+// OAuth 1.0
+$token = $user->token;
+$tokenSecret = $user->tokenSecret;
+
+// All providers
+$user->getId();
+$user->getNickname();
+$user->getName();
+$user->getEmail();
+$user->getAvatar();
+```
+
+### userFromToken (OAuth2)
+
+If you already have a valid access token:
+
+```php
+<?php
+
+$user = Socialite::driver('github')->userFromToken($token);
+```
+
+Supports Facebook Limited Login OIDC tokens as well.
+
+### Stateless Authentication
+
+Disable session state verification for APIs:
+
+```php
+<?php
+
+return Socialite::driver('google')->stateless()->user();
+```
+
+## Testing
+
+### Faking Redirect
+
+```php
+<?php
+
+use Laravel\Socialite\Socialite;
+
+test('user is redirected to github', function () {
+    Socialite::fake('github');
+
+    $response = $this->get('/auth/github/redirect');
+
+    $response->assertRedirect();
+});
+```
+
+### Faking Callback
+
+```php
+<?php
+
+use Laravel\Socialite\Socialite;
+use Laravel\Socialite\Two\User;
+
+test('user can login with github', function () {
+    Socialite::fake('github', (new User)->map([
+        'id' => 'github-123',
+        'name' => 'Jason Beggs',
+        'email' => 'jason@example.com',
+    ]));
+
+    $response = $this->get('/auth/github/callback');
+
+    $response->assertRedirect('/dashboard');
+
+    $this->assertDatabaseHas('users', [
+        'name' => 'Jason Beggs',
+        'email' => 'jason@example.com',
+        'github_id' => 'github-123',
+    ]);
+});
+```
+
+### Customizing the Fake User
+
+```php
+<?php
+
+$fakeUser = (new User)->map([
+    'id' => 'github-123',
+    'name' => 'Jason Beggs',
+    'email' => 'jason@example.com',
+])->setToken('fake-token')
+  ->setRefreshToken('fake-refresh-token')
+  ->setExpiresIn(3600)
+  ->setApprovedScopes(['read', 'write']);
+```
+
+## Best Practices
+
+- Store `{provider}_id`, `{provider}_token`, and `{provider}_refresh_token` on the users table
+- Use `updateOrCreate` to handle both first-time login and re-authentication
+- Use `stateless()` for API-only apps or when you don't need session state
+- Validate the user's email exists before creating an account (some providers may not return it)
+- Register community providers via `SocialiteProviders` if not natively supported
+- Always handle the case where the OAuth callback fails (e.g. user denies access)

--- a/skills/laravel-specialist/references/validation.md
+++ b/skills/laravel-specialist/references/validation.md
@@ -1,0 +1,518 @@
+# Validation
+
+## Quickstart
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class PostController
+{
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+            'category_id' => ['required', 'exists:categories,id'],
+            'tags' => ['nullable', 'array'],
+            'tags.*' => ['exists:tags,id'],
+            'published_at' => ['nullable', 'date', 'after:now'],
+        ]);
+
+        $post = Post::create($validated);
+
+        return redirect()->route('posts.show', $post);
+    }
+}
+```
+
+## Form Request Validation
+
+```bash
+php artisan make:request StorePostRequest
+```
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'min:3', 'max:255'],
+            'slug' => ['required', 'string', Rule::unique('posts', 'slug')],
+            'content' => ['required', 'string', 'min:10'],
+            'category_id' => ['required', 'exists:categories,id'],
+            'tags' => ['array'],
+            'tags.*' => ['exists:tags,id'],
+            'published_at' => ['nullable', 'date', 'after_or_equal:today'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'title.required' => 'A post title is required.',
+            'title.min' => 'The title must be at least :min characters.',
+            'slug.unique' => 'This slug is already in use.',
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'slug' => str($this->title)->slug(),
+        ]);
+    }
+
+    protected function passedValidation(): void
+    {
+        $this->merge([
+            'excerpt' => str($this->content)->limit(150),
+        ]);
+    }
+
+    public function after(): array
+    {
+        return [
+            function ($validator) {
+                if ($this->spamDetected($this->content)) {
+                    $validator->errors()->add('content', 'Content appears to be spam.');
+                }
+            },
+        ];
+    }
+
+    private function spamDetected(string $content): bool
+    {
+        return false;
+    }
+}
+```
+
+Using the form request in a controller:
+
+```php
+use App\Http\Requests\StorePostRequest;
+use App\Models\Post;
+
+public function store(StorePostRequest $request): Post
+{
+    return Post::create($request->validated());
+}
+```
+
+## Form Request Attributes
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Attributes\StopOnFirstFailure;
+
+#[StopOnFirstFailure]
+class StorePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+        ];
+    }
+}
+```
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Attributes\FailOnUnknownFields;
+
+#[FailOnUnknownFields]
+class UpdatePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}
+```
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Attributes\RedirectTo;
+
+#[RedirectTo('/dashboard')]
+class StorePostRequest extends FormRequest
+{
+    // On validation failure, redirect to /dashboard
+}
+```
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Attributes\ErrorBag;
+
+#[ErrorBag('postCreation')]
+class StorePostRequest extends FormRequest
+{
+    // Errors go to the 'postCreation' error bag
+}
+```
+
+## Manually Creating Validators
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Validator;
+
+$validator = Validator::make($request->all(), [
+    'email' => ['required', 'email'],
+    'password' => ['required', 'min:8'],
+]);
+
+if ($validator->fails()) {
+    return redirect()->back()
+        ->withErrors($validator)
+        ->withInput();
+}
+
+$validated = $validator->validated();
+
+// Retrieve only specific safe fields
+$safe = $validator->safe()->only(['email', 'name']);
+$exceptPassword = $validator->safe()->except(['password']);
+```
+
+## Named Error Bags
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Validator;
+
+$validator = Validator::make($request->all(), [
+    'title' => ['required', 'string'],
+    'content' => ['required', 'string'],
+]);
+
+if ($validator->fails()) {
+    return redirect()->back()
+        ->withErrors($validator, 'postCreation');
+}
+```
+
+```blade
+@if ($errors->postCreation->any())
+    <div class="alert alert-danger">
+        <ul>
+            @foreach ($errors->postCreation->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+```
+
+## Available Validation Rules
+
+| Rule | Description |
+|------|-------------|
+| `required` | Field must be present and non-empty |
+| `string` | Must be a string |
+| `integer` | Must be an integer |
+| `numeric` | Must be numeric |
+| `boolean` | Must be boolean-ish |
+| `array` | Must be an array |
+| `email` | Must be a valid email |
+| `url` | Must be a valid URL |
+| `date` | Must be a valid date |
+| `date_format:Y-m-d` | Must match the given format |
+| `after:today` | Must be after the given date |
+| `before:2025-01-01` | Must be before the given date |
+| `min:3` | Minimum length or value |
+| `max:255` | Maximum length or value |
+| `between:1,10` | Must be between the given range |
+| `size:16` | Must be exactly the given size |
+| `in:active,inactive` | Must be one of the given values |
+| `not_in:draft` | Must not be one of the given values |
+| `exists:users,id` | Must exist in the database |
+| `unique:posts,slug` | Must be unique in the database |
+| `confirmed` | Must match `field_confirmation` |
+| `current_password` | Must match the user's current password |
+| `image` | Must be an image file |
+| `mimes:pdf,docx` | Must be one of the given MIME types |
+| `mimetypes:image/jpeg` | Must match the given MIME type |
+| `file` | Must be a file upload |
+| `size:2048` | File size in KB |
+| `prohibited` | Field must be empty or absent |
+| `prohibited_if:status,draft` | Field must be empty when another field matches |
+| `prohibits:field1,field2` | If present, the other fields must be empty |
+| `required_if:status,draft` | Required when another field matches |
+| `required_with:title` | Required when another field is present |
+| `required_unless:status,published` | Required unless another field matches |
+| `gt:field` | Must be greater than another field |
+| `lt:field` | Must be less than another field |
+| `regex:/^[a-z]+$/` | Must match the pattern |
+
+## Conditionally Adding Rules
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Validator;
+
+$validator = Validator::make($data, [
+    'email' => ['required', 'email'],
+    'role' => ['required', 'string'],
+    'notify_all' => ['boolean'],
+]);
+
+$validator->sometimes('notification_email', 'email', function ($input) {
+    return $input->notify_all === true;
+});
+
+$validator->sometimes('expires_at', 'date|after:today', function ($input) {
+    return $input->role === 'temporary';
+});
+```
+
+```php
+// In a Form Request
+public function rules(): array
+{
+    $rules = [
+        'email' => ['required', 'email'],
+        'role' => ['required', 'string'],
+    ];
+
+    if ($this->role === 'admin') {
+        $rules['permissions'] = ['required', 'array'];
+        $rules['permissions.*'] = ['exists:permissions,id'];
+    }
+
+    return $rules;
+}
+```
+
+## Validating Arrays (Nested)
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Validator;
+
+$validator = Validator::make($request->all(), [
+    'users' => ['required', 'array'],
+    'users.*.email' => ['required', 'email', 'distinct'],
+    'users.*.name' => ['required', 'string', 'max:255'],
+    'users.*.roles' => ['array'],
+    'users.*.roles.*' => ['exists:roles,id'],
+]);
+
+// Access validated nested data
+$validated = $validator->validated();
+```
+
+```php
+// In a Form Request
+public function rules(): array
+{
+    return [
+        'items' => ['required', 'array', 'min:1'],
+        'items.*.product_id' => ['required', 'exists:products,id'],
+        'items.*.quantity' => ['required', 'integer', 'min:1', 'max:100'],
+        'items.*.price' => ['required', 'numeric', 'min:0'],
+    ];
+}
+```
+
+## Custom Validation Rules
+
+### Closure Rules
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Validator;
+
+$validator = Validator::make($request->all(), [
+    'coupon' => [
+        'required',
+        'string',
+        function (string $attribute, mixed $value, \Closure $fail) {
+            if (!Coupon::isValid($value)) {
+                $fail('The :attribute is invalid or expired.');
+            }
+        },
+    ],
+]);
+```
+
+Stopping on first failure:
+
+```php
+function (string $attribute, mixed $value, \Closure $fail) {
+    if (!Coupon::isValid($value)) {
+        $fail('The :attribute is invalid or expired.')->translate();
+    }
+},
+```
+
+### Rule Objects
+
+```bash
+php artisan make:rule Uppercase
+```
+
+```php
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class Uppercase implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (strtoupper($value) !== $value) {
+            $fail('The :attribute must be uppercase.');
+        }
+    }
+}
+```
+
+Using the rule:
+
+```php
+use App\Rules\Uppercase;
+
+'name' => ['required', 'string', new Uppercase],
+```
+
+## Working with Validated Input
+
+```php
+// From Form Request
+$validated = $request->validated();
+
+// Only specific fields
+$data = $request->safe()->only(['title', 'content']);
+$data = $request->safe()->except(['tags']);
+
+// From manual validator
+$validated = $validator->validated();
+$safe = $validator->safe()->only(['email']);
+$safe = $validator->safe()->except(['password']);
+```
+
+## Error Messages in Views
+
+```blade
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+@error('title')
+    <span class="text-danger">{{ $message }}</span>
+@enderror
+```
+
+## After Validation Hooks
+
+```php
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'content' => ['required', 'string'],
+        ];
+    }
+
+    protected function passedValidation(): void
+    {
+        $this->merge([
+            'slug' => str($this->title)->slug(),
+            'user_id' => auth()->id(),
+        ]);
+    }
+
+    public function after(): array
+    {
+        return [
+            function ($validator) {
+                if ($this->duplicateDetected()) {
+                    $validator->errors()->add('title', 'A post with this title already exists.');
+                }
+            },
+        ];
+    }
+
+    private function duplicateDetected(): bool
+    {
+        return false;
+    }
+}
+```
+
+## Best Practices
+
+1. **Use Form Requests** - Keep validation logic out of controllers for reuse
+2. **Validate at the boundary** - Validate all input before any business logic
+3. **Use specific validation rules** - Prefer `exists:table,column` over manual DB checks
+4. **Leverage `safe()->only()`** - Avoid mass-assignment vulnerabilities by whitelisting fields
+5. **Use custom Rule objects** - Encapsulate complex validation logic
+6. **Return meaningful error messages** - Use `:attribute` and `:value` placeholders
+7. **Use `after()` hooks** - For cross-field or database validation after individual field checks
+8. **Validate arrays with `*` notation** - Use `items.*.product_id` for nested validation
+9. **Use `sometimes` for updates** - Only validate present fields during updates
+10. **Stop on first failure when appropriate** - Use `#[StopOnFirstFailure]` for performance
+11. **Use `#[FailOnUnknownFields]`** - Prevent unexpected extra fields in API requests

--- a/skills/laravel-specialist/references/view-components.md
+++ b/skills/laravel-specialist/references/view-components.md
@@ -1,0 +1,616 @@
+# Blade Templates & View Components
+
+## Displaying Data
+
+```php
+// Basic display - automatically escaped
+{{ $name }}
+
+ // Unescaped display (careful with XSS)
+{!! $htmlContent !!}
+
+// Display with default value
+{{ $name ?? 'Guest' }}
+
+ // Calling PHP functions
+{{ time() }}
+{{ now()->format('Y-m-d') }}
+```
+
+```php
+// Blade and JavaScript frameworks
+// Use @ to prevent Blade from processing curly braces
+<h1>Laravel</h1>
+Hello, @{{ name }}.
+
+ // Escape Blade directives
+@@if()
+
+// Render JSON for JavaScript
+<script>
+    var app = {{ Js::from($array) }};
+</script>
+
+// Use @verbatim for large blocks
+@verbatim
+    <div class="container">
+        Hello, {{ name }}.
+    </div>
+@endverbatim
+```
+
+## Blade Directives
+
+### Conditionals
+
+```php
+@if (count($records) === 1)
+    I have one record!
+@elseif (count($records) > 1)
+    I have multiple records!
+@else
+    No records found
+@endif
+
+@unless (Auth::check())
+    You are not signed in.
+@endunless
+
+@isset($records)
+    $records is defined and not null
+@endisset
+
+@empty($records)
+    $records is empty
+@endempty
+```
+
+```php
+// Authentication directives
+@auth
+    User is authenticated
+@endauth
+
+@guest
+    User is a guest
+@endguest
+
+// With guard
+@auth('admin')
+    Admin authenticated
+@endauth
+
+@guest('admin')
+    Admin guest
+@endguest
+```
+
+```php
+// Environment directives
+@production
+    Production content
+@endproduction
+
+@env('local')
+    Local environment
+@endenv
+
+@env(['staging', 'production'])
+    Staging or production
+@endenv
+```
+
+```php
+// Session and context directives
+@session('status')
+    <div class="alert">{{ $value }}</div>
+@endsession
+
+@context('canonical')
+    <link href="{{ $value }}" rel="canonical">
+@endcontext
+```
+
+### Loops
+
+```php
+@for ($i = 0; $i < 10; $i++)
+    Current value: {{ $i }}
+@endfor
+
+@foreach ($users as $user)
+    <p>User: {{ $user->name }}</p>
+@endforeach
+
+@forelse($users as $user)
+    <li>{{ $user->name }}</li>
+@empty
+    <p>No users found</p>
+@endforelse
+
+@while (true)
+    <p>Looping forever</p>
+@endwhile
+```
+
+```php
+// Loop variable
+@foreach ($users as $user)
+    @if ($loop->first) First item @endif
+    @if ($loop->last) Last item @endif
+    Index: {{ $loop->index }}
+    Iteration: {{ $loop->iteration }}
+    Remaining: {{ $loop->remaining }}
+    Count: {{ $loop->count }}
+    Even: {{ $loop->even }}
+    Odd: {{ $loop->odd }}
+    Depth: {{ $loop->depth }}
+@endforeach
+
+// Nested loops - access parent
+@foreach ($users as $user)
+    @foreach ($user->posts as $post)
+        @if ($loop->parent->first)
+            First post of first user
+        @endif
+    @endforeach
+@endforeach
+```
+
+```php
+// Continue and break
+@foreach ($users as $user)
+    @continue($user->type == 1)
+    @break($user->number == 5)
+    <li>{{ $user->name }}</li>
+@endforeach
+```
+
+### Switch Statements
+
+```php
+@switch($i)
+    @case(1)
+        First case
+        @break
+    @case(2)
+        Second case
+        @break
+    @default
+        Default case
+@endswitch
+```
+
+## Component Directives
+
+```php
+// Conditional classes
+<span @class([
+    'p-4',
+    'font-bold' => $isActive,
+    'text-gray-500' => !$isActive,
+    'bg-red-500' => $hasError,
+])></span>
+
+// Conditional styles
+<span @style([
+    'background-color: red',
+    'font-weight: bold' => $isImportant,
+])></span>
+
+// Form helpers
+<input type="checkbox" @checked(old('active', $user->active)) />
+
+<select name="version">
+    @foreach($versions as $version)
+        <option value="{{ $version }}" @selected(old('version') == $version)>
+            {{ $version }}
+        </option>
+    @endforeach
+</select>
+
+<button @disabled($errors->isNotEmpty())>Submit</button>
+<input @readonly(!$isEditable) />
+<input @required($isRequired) />
+```
+
+## Including Subviews
+
+```php
+@include('shared.errors')
+
+@include('view.name', ['status' => 'complete'])
+
+@includeIf('view.name')
+@includeWhen($boolean, 'view.name')
+@includeUnless($boolean, 'view.name')
+@includeFirst(['custom.admin', 'admin'])
+
+// Render collection
+@each('partials.item', $items, 'item', 'partials.empty')
+
+// Isolated - no parent variables
+@includeIsolated('view.name', ['user' => $user])
+```
+
+## Raw PHP
+
+```php
+@php
+    $counter = 1;
+@endphp
+
+@use('App\Models\Flight')
+@use('App\Models\Flight', 'FlightModel')
+@use('App\Models\{Flight, Airport}')
+
+// Import functions and constants
+@use(function App\Helpers\format_currency)
+@use(const App\Constants\MAX_ATTEMPTS)
+@use(function App\Helpers\format_currency, 'formatMoney')
+
+// Comments
+{{-- This comment will not be in rendered HTML --}}
+```
+
+## Stacks
+
+```php
+// Push to stack
+@push('scripts')
+    <script src="/js/app.js"></script>
+@endpush
+
+@prepend('scripts')
+    <script src="/vendor.js"></script>
+@endprepend
+
+// Render stack
+@stack('scripts')
+
+// Render once (useful in loops)
+@once
+    @push('scripts')
+        <script>console.log('loaded');</script>
+    @endpush
+@endonce
+
+@pushOnce('scripts', 'unique-id')
+    <script src="/js/chart.js"></script>
+@endPushOnce
+```
+
+## Blade Components
+
+### Creating Components
+
+```bash
+php artisan make:component Alert
+php artisan make:component Forms/Input
+php artisan make:component Alert --inline
+```
+
+### Component Class
+
+```php
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+class Alert extends Component
+{
+    public function __construct(
+        public string $type = 'info',
+        public string $message = '',
+    ) {}
+
+    public function render(): View
+    {
+        return view('components.alert');
+    }
+
+    public function shouldRender(): bool
+    {
+        return Str::length($this->message) > 0;
+    }
+}
+```
+
+### Component View
+
+```php
+{{-- resources/views/components/alert.blade.php --}}
+@props(['type' => 'info', 'message' => ''])
+
+<div class="alert alert-{{ $type }}" {{ $attributes }}>
+    {{ $message }}
+    {{ $slot }}
+</div>
+```
+
+### Using Components
+
+```php
+<x-alert type="error" :message="$errorMsg" class="mb-4" />
+
+<x-alert type="success">
+    Operation completed successfully!
+</x-alert>
+
+// Nested components
+<x-card>
+    <x-card.header>Title</x-card.header>
+    <x-card.body>Content</x-card.body>
+</x-card>
+```
+
+## Component Data Binding
+
+```php
+// Short attribute syntax
+<x-profile :$userId :$name />
+
+// Equivalent to
+<x-profile :user-id="$userId" :name="$name" />
+
+// Component methods accessible in view
+public function isSelected(string $option): bool
+{
+    return $option === $this->selected;
+}
+
+// In view
+<option {{ $isSelected($value) ? 'selected' : '' }}>
+    {{ $label }}
+</option>
+
+// Accessing parent data
+{{ $attributes->get('class') }}
+{{ $attributes->has('disabled') }}
+```
+
+## Component Attributes
+
+```php
+// Merge attributes with defaults
+<div {{ $attributes->merge(['class' => 'bg-white p-4']) }}>
+    {{ $slot }}
+</div>
+
+// Conditional merge
+<div {{ $attributes->class(['hidden' => $isHidden]) }}>
+    {{ $slot }}
+</div>
+
+// Override specific attribute
+{{ $attributes->except(['method']) }}
+{{ $attributes->only(['class', 'id']) }}
+```
+
+## Slots
+
+```php
+// resources/views/components/modal.blade.php
+<div class="modal">
+    <div class="modal-header">
+        {{ $title }}
+    </div>
+    <div class="modal-body">
+        {{ $slot }}
+    </div>
+    @isset($footer)
+        <div class="modal-footer">
+            {{ $footer }}
+        </div>
+    @endisset
+</div>
+
+// Usage
+<x-modal>
+    <x-slot name="title">Confirm Action</x-slot>
+    Are you sure?
+    <x-slot name="footer">
+        <button>Cancel</button>
+    </x-slot>
+</x-modal>
+```
+
+## Anonymous Components
+
+```php
+// File: resources/views/components/alert.blade.php
+@props(['type' => 'info'])
+
+<div class="alert alert-{{ $type }}">
+    {{ $slot }}
+</div>
+
+// Usage - no class needed
+<x-alert type="error">Error message</x-alert>
+```
+
+## Dynamic Components
+
+```php
+<x-dynamic-component :component="$componentName" />
+
+// Or using component method
+@component($componentName, ['title' => 'Hello'])
+    Content
+@endcomponent
+```
+
+## View Composers
+
+```php
+// Register in AppServiceProvider
+use Illuminate\Support\Facades\View;
+
+public function boot(): void
+{
+    // Class-based composer
+    View::composer('profile', ProfileComposer::class);
+
+    // Closure-based composer
+    View::composer('dashboard', function (View $view) {
+        $view->with('stats', getStats());
+    });
+
+    // Multiple views
+    View::composer(['profile', 'dashboard'], MultiComposer::class);
+
+    // Wildcard - all views
+    View::composer('*', function (View $view) {
+        $view->with('appName', config('app.name'));
+    });
+}
+```
+
+```php
+// Composer class
+namespace App\View\Composers;
+
+use App\Repositories\UserRepository;
+use Illuminate\View\View;
+
+class ProfileComposer
+{
+    public function __construct(
+        protected UserRepository $users,
+    ) {}
+
+    public function compose(View $view): void
+    {
+        $view->with('count', $this->users->count());
+    }
+}
+```
+
+## View Creators
+
+```php
+// Similar to composers but runs immediately on instantiation
+View::creator('profile', ProfileCreator::class);
+
+class ProfileCreator
+{
+    public function create(View $view): void
+    {
+        $view->with('quickStats', cache()->remember('stats', 60, function () {
+            return ['users' => User::count()];
+        }));
+    }
+}
+```
+
+## Sharing Data With All Views
+
+```php
+// In AppServiceProvider
+public function boot(): void
+{
+    View::share('siteName', config('app.name'));
+    View::share('categories', Category::all());
+}
+```
+
+## Service Injection
+
+```php
+@inject('stats', 'App\Services\StatsService')
+
+{{ $stats->getTotal() }}
+```
+
+## Extending Blade
+
+```php
+// Custom if statements
+use Illuminate\Support\Facades\Blade;
+
+public function boot(): void
+{
+    Blade::if('env', function ($environment) {
+        return app()->environment($environment);
+    });
+}
+
+@env('local')
+    Local
+@endenv
+```
+
+```php
+// Custom echo handlers
+Blade::stringable(function ($value) {
+    return str($value)->upper();
+});
+
+{{ $name }} // Outputs uppercase
+```
+
+## Building Layouts
+
+### Using Components
+
+```php
+{{-- layouts/app.blade.php --}}
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ $title ?? 'Default' }}</title>
+    {{ $scripts }}
+</head>
+<body>
+    {{ $slot }}
+</body>
+</html>
+
+{{-- Usage --}}
+<x-layout>
+    <x-slot name="title">Page Title</x-slot>
+    <p>Content here</p>
+</x-layout>
+```
+
+### Using Template Inheritance
+
+```php
+{{-- layouts/app.blade.php --}}
+<html>
+<body>
+    @yield('content')
+</body>
+</html>
+
+{{-- child.blade.php --}}
+@extends('layouts.app')
+
+@section('content')
+    <p>My content</p>
+@endsection
+```
+
+## View Optimization
+
+```bash
+# Precompile all views
+php artisan view:cache
+
+# Clear view cache
+php artisan view:clear
+```
+
+## Best Practices
+
+1. **Use components over includes** - Better data binding and reusability
+2. **Leverage short attribute syntax** - Cleaner component usage
+3. **Use anonymous components** - For simple UI elements without logic
+4. **Prefer slots over passing data** - More flexible content
+5. **Use View Composers** - Centralize shared view data
+6. **Cache compiled views in production** - Use `view:cache`
+7. **Avoid complex logic in views** - Move to controllers or services
+8. **Use @class and @style** - Clean conditional styling
+9. **Use eager loading** - Prevent N+1 in views with relationships
+10. **Leverage service injection** - Keep views clean of business logic


### PR DESCRIPTION
- Add references for: artisan, authorization, broadcasting, collections, concurrency, container, events, fortify, helpers, inertia, notifications, packages, sanctum, socialite, validation, view-components
- Update SKILL.md routing table with 14 new entries and code examples
- Bump version 1.1.0 → 1.2.0