### PR TITLE
Require user approval before running terraform apply

### DIFF
--- a/skills/terraform-engineer/SKILL.md
+++ b/skills/terraform-engineer/SKILL.md
@@ -24,7 +24,8 @@ Senior Terraform engineer specializing in infrastructure as code across AWS, Azu
 3. **Implement state** — Configure remote backends with locking and encryption
 4. **Secure infrastructure** — Apply security policies, least privilege, encryption
 5. **Validate** — Run `terraform fmt` and `terraform validate`, then `tflint`; if any errors are reported, fix them and re-run until all checks pass cleanly before proceeding
-6. **Plan and apply** — Run `terraform plan -out=tfplan`, review output carefully, then `terraform apply tfplan`; if the plan fails, see error recovery below
+6. **Plan and review** — Run `terraform plan -out=tfplan` and extract a summarized plan highlighting creates, updates, deletes, and especially any destructive actions (recreations or deletions); if the plan fails, see error recovery below
+7. **Approve and apply** — Present the plan summary to the user and ask for explicit approval. Only execute `terraform apply tfplan` after receiving confirmation. Refuse to apply the plan if approval is withheld, or if destructive changes are present and the user has not explicitly accepted them
 
 ### Error Recovery
 


### PR DESCRIPTION
This PR updates the core workflow in `SKILL.md` for the Terraform engineer skill to introduce a mandatory human-in-the-loop approval checkpoint between the terraform plan and terraform apply phases.

Previously, the workflow allowed the agent to immediately execute an apply after planning without explicit consent.

### Fixes https://github.com/Jeffallan/claude-skills/issues/211