### PR TITLE
Fix: Avoid hard-coded Cohere API key in RAG skill

### DIFF
--- a/skills/rag-architect/SKILL.md
+++ b/skills/rag-architect/SKILL.md
@@ -128,10 +128,14 @@ def hybrid_search(query: str, tenant_id: str, top_k: int = 20) -> list:
 
 ### 4. Reranking Top-K Results
 
+Load provider API keys from environment variables or a secrets manager; never commit them to source code.
+
 ```python
+import os
+
 import cohere
 
-co = cohere.Client("YOUR_API_KEY")
+co = cohere.Client(os.environ["COHERE_API_KEY"])
 
 def rerank(query: str, results: list, top_n: int = 5) -> list:
     docs = [r.payload.get("text", "") for r in results]


### PR DESCRIPTION
## Summary

- Replace the hard-coded Cohere API key placeholder in the RAG reranking example with `COHERE_API_KEY` from the environment.
- Add a short note to load provider keys from environment variables or a secrets manager and avoid committing API keys.

## Impact

This keeps the documentation example aligned with safer credential handling while preserving the existing reranking flow.

Fixes #210.

## Validation

- `git diff --check`
- `UV_CACHE_DIR=../uv-cache UV_PYTHON_INSTALL_DIR=../uv-python uv run --python 3.11 --with pyyaml python scripts/validate-skills.py --skill rag-architect`
- `UV_CACHE_DIR=../uv-cache UV_PYTHON_INSTALL_DIR=../uv-python uv run --python 3.11 --with pyyaml python scripts/validate-skills.py`
- `UV_CACHE_DIR=../uv-cache UV_PYTHON_INSTALL_DIR=../uv-python uv run --python 3.11 --with pyyaml python scripts/validate-markdown.py --check`
- `UV_CACHE_DIR=../uv-cache UV_PYTHON_INSTALL_DIR=../uv-python uv run --python 3.11 --with pyyaml python scripts/update-docs.py --check`
- `./site/node_modules/.bin/prettier --check skills/rag-architect/SKILL.md`
- `./site/node_modules/.bin/prettier --check "skills/**/*.md" "docs/**/*.md" "*.md" "research/**/*.md"`
