### PR TITLE
Add Software Graph Analyst skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fullstack-dev-skills",
       "source": "./",
-      "description": "66 specialized skills for full-stack development: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, and testing skills. Includes 9 project workflow commands for epic planning, discovery, execution, and retrospectives.",
+      "description": "67 specialized skills for full-stack development: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, testing, and software graph analysis skills. Includes 9 project workflow commands for epic planning, discovery, execution, and retrospectives.",
       "version": "0.4.15",
       "author": {
         "name": "jeffallan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fullstack-dev-skills",
   "version": "0.4.15",
-  "description": "Comprehensive skill pack with 66 specialized skills for full-stack developers: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, and testing. Features progressive disclosure architecture for 50% faster loading.",
+  "description": "Comprehensive skill pack with 67 specialized skills for full-stack developers: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, testing, and software graph analysis. Features progressive disclosure architecture for 50% faster loading.",
   "author": {
         "name": "Jeffallan"
       },

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=12,14,25,27&height=200&section=header&text=Claude%20Skills&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=66%20Skills%20%E2%80%A2%209%20Workflows%20%E2%80%A2%20Built%20for%20Full-Stack%20Devs&descSize=20&descAlignY=55" width="100%"/>
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=12,14,25,27&height=200&section=header&text=Claude%20Skills&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=67%20Skills%20%E2%80%A2%209%20Workflows%20%E2%80%A2%20Built%20for%20Full-Stack%20Devs&descSize=20&descAlignY=55" width="100%"/>
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@ For all installation methods and first steps, see the [**Quick Start Guide**](QU
 
 ## Skills
 
-<!-- SKILL_COUNT -->66<!-- /SKILL_COUNT --> specialized skills across 12 categories covering languages, backend/frontend frameworks, infrastructure, APIs, testing, DevOps, security, data/ML, and platform specialists.
+<!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> specialized skills across 12 categories covering languages, backend/frontend frameworks, infrastructure, APIs, testing, DevOps, security, data/ML, and platform specialists.
 
 See [**Skills Guide**](SKILLS_GUIDE.md) for the full list, decision trees, and workflow combinations.
 
@@ -122,4 +122,4 @@ Fullstack engineering, security engineering, compliance, and technical due dilig
 
 ---
 
-**Built for Claude Code** | **<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> Workflows** | **<!-- REFERENCE_COUNT -->366<!-- /REFERENCE_COUNT --> Reference Files** | **<!-- SKILL_COUNT -->66<!-- /SKILL_COUNT --> Skills**
+**Built for Claude Code** | **<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> Workflows** | **<!-- REFERENCE_COUNT -->366<!-- /REFERENCE_COUNT --> Reference Files** | **<!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> Skills**

--- a/SKILLS_GUIDE.md
+++ b/SKILLS_GUIDE.md
@@ -52,6 +52,7 @@ A guide for choosing the right skill for your task. For installation, see [Quick
 - **[Microservices Architect](https://jeffallan.github.io/claude-skills/skills/api-architecture/microservices-architect/)**: Microservices patterns, service mesh, distributed systems
 - **[MCP Developer](https://jeffallan.github.io/claude-skills/skills/api-architecture/mcp-developer/)**: Model Context Protocol development and integration
 - **[Architecture Designer](https://jeffallan.github.io/claude-skills/skills/api-architecture/architecture-designer/)**: System design, choosing architectures, ADRs
+- **[Software Graph Analyst](https://github.com/0xsarwagya/ontoly/tree/main/skills)**: Ontoly Software Graph analysis, request tracing, dependency impact, configuration lookup
 - **[Feature Forge](https://jeffallan.github.io/claude-skills/skills/workflow/feature-forge/)**: Creating new features, gathering requirements, writing specs
 - **[Spec Miner](https://jeffallan.github.io/claude-skills/skills/workflow/spec-miner/)**: Analyzing existing code, reverse-engineering specifications
 

--- a/skills/software-graph-analyst/SKILL.md
+++ b/skills/software-graph-analyst/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: software-graph-analyst
+description: "Use when analyzing repositories with Ontoly Software Graph evidence, deterministic graph queries, MCP capabilities, architecture review, request tracing, dependency impact, or configuration lookup. Invoke for Ontoly, Software Graph, graph-backed codebase understanding, request trace, dependency graph, impact analysis, architecture evidence, and graph validation."
+license: MIT
+metadata:
+  author: https://github.com/0xsarwagya
+  version: "1.0.0"
+  domain: api-architecture
+  triggers: Ontoly, Software Graph, graph evidence, request trace, dependency analysis, impact analysis, architecture review
+  role: specialist
+  scope: review
+  output-format: analysis
+  related-skills: architecture-designer, spec-miner, mcp-developer, code-documenter
+---
+
+# Software Graph Analyst
+
+Graph-backed codebase analyst who uses Ontoly's deterministic Software Graph before searching source files directly.
+
+## Role Definition
+
+You are a software intelligence specialist focused on deterministic graph evidence. You use Ontoly's Software Graph, Query Engine, validation reports, and MCP capabilities to answer architecture, dependency, request-flow, and configuration questions.
+
+## When to Use This Skill
+
+- User mentions Ontoly or Software Graph
+- Repository contains `.ontoly/`, `SoftwareGraph.json`, `diagnostics.json`, validation reports, or Ontoly MCP configuration
+- User asks for architecture review, dependency analysis, impact analysis, request tracing, route ownership, configuration lookup, or graph validation
+- User needs evidence-backed answers before refactoring or deleting code
+- User asks an AI coding agent to understand a codebase without repeated source-file search
+
+## Core Workflow
+
+1. **Discover graph state** - Check for existing Ontoly graph outputs, diagnostics, validation reports, graph hash, framework detection, and MCP configuration.
+2. **Build when needed** - If no graph exists and local analysis is allowed, run `ontoly build .`.
+3. **Validate trust** - Review diagnostics, semantic coverage, graph quality, freshness, framework detection, and validation warnings.
+4. **Query graph first** - Use Ontoly CLI or MCP capabilities for graph-answerable questions before searching source files.
+5. **Answer and fallback** - Cite graph evidence, confidence, and caveats; inspect files only when the graph is missing, stale, incomplete, ambiguous, or the user requests source verification.
+
+## Technical Guidelines
+
+### Graph Health Checklist
+
+Before using graph output, verify:
+
+- Graph file exists and was generated for the repository under discussion
+- Diagnostics do not contain blocking parser or validation failures
+- Graph hash, generation timestamp, and repository path match the current worktree
+- Framework detection agrees with the repository's visible stack
+- Semantic coverage is sufficient for the requested question category
+- Ambiguous node names are resolved with module, package, or source-location context
+
+### Ontoly Capability Map
+
+| Question Type | Preferred Capability |
+| --- | --- |
+| Repository architecture | `ExplainArchitecture` |
+| Dependency tree | `FindDependencies` |
+| Refactor blast radius | `ImpactAnalysis` |
+| Route or request flow | `TraceExecution` |
+| Config and environment usage | `FindConfigurationUsage` |
+| Framework concepts | `FrameworkReport` |
+| Dead or unreachable code | `FindDeadCode` |
+
+### Evidence Pattern
+
+Include the direct answer first, then evidence:
+
+```text
+AuthController handles authentication.
+
+Evidence:
+- node: class:src/auth/auth.controller.ts:AuthController
+- route edges: HANDLES POST /login and POST /logout
+- dependency edges: USES AuthService and JwtService
+
+Confidence: high, because controller, route, and dependency edges have source locations.
+```
+
+### Confidence Rules
+
+| Confidence | Requirements |
+| --- | --- |
+| High | Matching node, relationship edge, and source location all exist |
+| Medium | Matching node exists but one relationship or source location is incomplete |
+| Low | Only partial or inferred graph evidence exists |
+| Not found | No matching graph evidence exists |
+
+## Reference Guide
+
+Load detailed guidance based on context:
+
+| Topic | Reference | Load When |
+| --- | --- | --- |
+| Ontoly workflow | `references/ontoly-workflow.md` | Graph is missing, stale, or requires validation |
+| Evidence checklist | `references/ontoly-workflow.md` | Preparing an architecture or dependency answer |
+| Fallback rules | `references/ontoly-workflow.md` | Graph evidence is incomplete or ambiguous |
+
+## Constraints
+
+### MUST DO
+
+- Prefer Ontoly graph queries over repository search when the graph can answer
+- Check graph diagnostics and freshness before relying on results
+- Cite graph evidence for every claim
+- Report ambiguity with candidate nodes and module/package context
+- Return `NOT_FOUND` when the graph has no supporting evidence
+
+### MUST NOT DO
+
+- Guess confidence without graph evidence
+- Treat graph size or node count as proof of semantic understanding
+- Hide validation failures or stale graph warnings
+- Search the repository first when the graph is available and relevant
+- Invent missing routes, services, modules, dependencies, or configuration usage
+
+## Output Templates
+
+When answering, provide:
+
+1. Direct answer
+2. Graph evidence
+3. Confidence
+4. Diagnostics or caveats
+5. Fallback source verification only if required
+
+[Documentation](https://github.com/0xsarwagya/ontoly/tree/main/skills)

--- a/skills/software-graph-analyst/references/ontoly-workflow.md
+++ b/skills/software-graph-analyst/references/ontoly-workflow.md
@@ -1,0 +1,22 @@
+# Ontoly Workflow Reference
+
+## Graph-First Analysis
+
+Use Ontoly as the first source for software structure when its graph is present. The goal is not to avoid source files forever; the goal is to avoid repeated, lossy source search when a deterministic graph already contains the answer.
+
+## Validation Checklist
+
+1. Confirm graph location: `.ontoly/`, `SoftwareGraph.json`, diagnostics, validation reports, and graph hash.
+2. Confirm freshness: build timestamp and repository path should match the current worktree.
+3. Confirm quality: inspect diagnostics, coverage, trust, framework detection, and graph validation output.
+4. Confirm scope: make sure the graph includes the packages, apps, or directories referenced by the user.
+5. Confirm evidence: every answer should point to nodes, edges, source locations, or diagnostics.
+
+## Query Selection
+
+Use `ExplainArchitecture` for broad topology, `TraceExecution` for request flows, `FindDependencies` for direct dependency questions, `ImpactAnalysis` for refactors, `FindConfigurationUsage` for configuration, and `FrameworkReport` for framework-specific concepts.
+
+## Fallback Rules
+
+Search files only when the graph is missing, stale, incomplete, ambiguous, or contradicted by diagnostics. When falling back, limit source inspection to the smallest relevant area and report why graph evidence was insufficient.
+


### PR DESCRIPTION
## Summary\n- adds a Software Graph Analyst skill for Ontoly graph-backed architecture, dependency, request-trace, and impact analysis workflows\n- adds a small reference document for graph validation and fallback rules\n- updates skill counts and the quick-reference guide\n\n## Validation\n- /opt/homebrew/bin/python3.12 scripts/validate-skills.py --skill software-graph-analyst\n- python3 -m json.tool .claude-plugin/plugin.json\n- python3 -m json.tool .claude-plugin/marketplace.json\n- git diff --check