### PR TITLE
fix: broken relative reference paths in vue-expert-js and react-expert

### DIFF
--- a/skills/react-expert/references/migration-class-to-modern.md
+++ b/skills/react-expert/references/migration-class-to-modern.md
@@ -924,7 +924,7 @@ export default async function UserProfile({ params }: { params: { id: string } }
 - SEO-critical content? → Server Component
 - Large dependencies? → Server Component (smaller client bundle)
 
-See reference: `react-expert/references/server-components.md`
+See reference: `references/server-components.md`
 
 ---
 

--- a/skills/vue-expert-js/SKILL.md
+++ b/skills/vue-expert-js/SKILL.md
@@ -37,9 +37,9 @@ Load detailed guidance based on context:
 | Testing | `references/testing-patterns.md` | Vitest, component testing, mocking |
 
 **For shared Vue concepts, defer to vue-expert:**
-- `vue-expert/references/composition-api.md` - Core reactivity patterns
-- `vue-expert/references/components.md` - Props, emits, slots
-- `vue-expert/references/state-management.md` - Pinia stores
+- `../vue-expert/references/composition-api.md` - Core reactivity patterns
+- `../vue-expert/references/components.md` - Props, emits, slots
+- `../vue-expert/references/state-management.md` - Pinia stores
 
 ## Code Patterns
 


### PR DESCRIPTION
## What

Four broken file references, found via an automated skill audit I'm building:

1. `skills/vue-expert-js/SKILL.md` — the "defer to vue-expert" section references `vue-expert/references/*.md` (3 files). Relative to the skill directory, that path doesn't exist; the shared references live in the sibling skill at `../vue-expert/references/`.

2. `skills/react-expert/references/migration-class-to-modern.md` — references `react-expert/references/server-components.md` from inside that same directory. Corrected to `references/server-components.md`, matching the convention used elsewhere in the skill.

## Why it matters

When an agent follows the vue-expert-js instruction to load a shared reference, the `Read` fails silently against the non-existent path, so the deferred content never loads.

## Diff

4 lines changed, no content changes — paths only.
