### PR TITLE
fix(readme): repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Fullstack engineering, security engineering, compliance, and technical due dilig
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Jeffallan/claude-skills&type=date&legend=top-left)](https://www.star-history.com/#Jeffallan/claude-skills&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Jeffallan/claude-skills&type=date&legend=top-left)](https://star-history.dera.page/#Jeffallan/claude-skills&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
The star history chart shown in the README is broken because the service it relies on has been hit by the GitHub stargazer API restrictions. This change points the chart at a working alternative so the repository's star history renders correctly again.