### PR TITLE
feat(skills): add accessibility engineer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "fullstack-dev-skills",
       "source": "./",
-      "description": "67 specialized skills for full-stack development: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, and testing skills. Includes 9 project workflow commands for epic planning, discovery, execution, and retrospectives.",
+      "description": "68 specialized skills for full-stack development: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, and testing skills. Includes 9 project workflow commands for epic planning, discovery, execution, and retrospectives.",
       "version": "0.4.16",
       "author": {
         "name": "jeffallan",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fullstack-dev-skills",
   "version": "0.4.16",
-  "description": "Comprehensive skill pack with 67 specialized skills for full-stack developers: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, and testing. Features progressive disclosure architecture for 50% faster loading.",
+  "description": "Comprehensive skill pack with 68 specialized skills for full-stack developers: 12 language experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript), 10 backend frameworks, 6 frontend/mobile, plus infrastructure, DevOps, security, and testing. Features progressive disclosure architecture for 50% faster loading.",
   "author": {
         "name": "Jeffallan"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New skill: `accessibility-engineer` — WCAG 2.2 implementation and audit guidance covering semantic HTML, ARIA interaction patterns, keyboard and screen-reader testing, automated regression checks, and evidence-based remediation
+
 ### Fixed
 - README banner (capsule-render URL) still displayed 66 skills after the v0.4.16 release; the counts are URL-encoded inside the image URL where no `<!-- SKILL_COUNT -->` marker can live, so `update-docs.py` never touched them. The script now rewrites the banner's `desc=` parameter from computed counts
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -62,7 +62,7 @@ Verify skills are working:
 
 ### 1. What's Included
 
-<!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> skills covering:
+<!-- SKILL_COUNT -->68<!-- /SKILL_COUNT --> skills covering:
 - 12 Language Experts (Python, TypeScript, Go, Rust, C++, Swift, Kotlin, C#, PHP, Java, SQL, JavaScript)
 - 7 Backend Framework Experts (NestJS, Django, FastAPI, Spring Boot, Laravel, Rails, .NET Core)
 - 7 Frontend & Mobile Experts (React, Next.js, Vue, Angular, React Native, Flutter)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=12,14,25,27&height=200&section=header&text=Claude%20Skills&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=67%20Skills%20%E2%80%A2%209%20Workflows%20%E2%80%A2%20Built%20for%20Full-Stack%20Devs&descSize=20&descAlignY=55" width="100%"/>
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=gradient&customColorList=12,14,25,27&height=200&section=header&text=Claude%20Skills&fontSize=80&fontColor=ffffff&animation=fadeIn&fontAlignY=35&desc=68%20Skills%20%E2%80%A2%209%20Workflows%20%E2%80%A2%20Built%20for%20Full-Stack%20Devs&descSize=20&descAlignY=55" width="100%"/>
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@ For all installation methods and first steps, see the [**Quick Start Guide**](QU
 
 ## Skills
 
-<!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> specialized skills across 12 categories covering languages, backend/frontend frameworks, infrastructure, APIs, testing, DevOps, security, data/ML, and platform specialists.
+<!-- SKILL_COUNT -->68<!-- /SKILL_COUNT --> specialized skills across 12 categories covering languages, backend/frontend frameworks, infrastructure, APIs, testing, DevOps, security, data/ML, and platform specialists.
 
 See [**Skills Guide**](SKILLS_GUIDE.md) for the full list, decision trees, and workflow combinations.
 
@@ -122,4 +122,4 @@ Fullstack engineering, security engineering, compliance, and technical due dilig
 
 ---
 
-**Built for Claude Code** | **<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> Workflows** | **<!-- REFERENCE_COUNT -->371<!-- /REFERENCE_COUNT --> Reference Files** | **<!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> Skills**
+**Built for Claude Code** | **<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> Workflows** | **<!-- REFERENCE_COUNT -->374<!-- /REFERENCE_COUNT --> Reference Files** | **<!-- SKILL_COUNT -->68<!-- /SKILL_COUNT --> Skills**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,8 @@
 
 **Version:** v<!-- VERSION -->0.4.16<!-- /VERSION --> (Released January 2026)
 
-- **<!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> Skills** across 12 domains
-- **<!-- REFERENCE_COUNT -->371<!-- /REFERENCE_COUNT --> Reference Files** with progressive disclosure architecture
+- **<!-- SKILL_COUNT -->68<!-- /SKILL_COUNT --> Skills** across 12 domains
+- **<!-- REFERENCE_COUNT -->374<!-- /REFERENCE_COUNT --> Reference Files** with progressive disclosure architecture
 - **30+ Frameworks** and technologies covered
 - **<!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> Project Workflow Commands** for epic planning, discovery, execution, and retrospectives
 - **50% Token Reduction** through selective disclosure architecture

--- a/SKILLS_GUIDE.md
+++ b/SKILLS_GUIDE.md
@@ -57,6 +57,7 @@ A guide for choosing the right skill for your task. For installation, see [Quick
 - **[Spec Miner](https://jeffallan.github.io/claude-skills/skills/workflow/spec-miner/)**: Analyzing existing code, reverse-engineering specifications
 
 ### Quality & Testing
+- **[Accessibility Engineer](https://jeffallan.github.io/claude-skills/skills/quality/accessibility-engineer/)**: WCAG 2.2 implementation, audits, remediation, and assistive-technology testing
 - **[Test Master](https://jeffallan.github.io/claude-skills/skills/quality/test-master/)**: Overall testing strategy (unit, integration, E2E, performance, security)
 - **[Playwright Expert](https://jeffallan.github.io/claude-skills/skills/quality/playwright-expert/)**: Browser automation and E2E testing
 - **[Code Reviewer](https://jeffallan.github.io/claude-skills/skills/quality/code-reviewer/)**: Conducting thorough code reviews
@@ -187,6 +188,7 @@ A guide for choosing the right skill for your task. For installation, see [Quick
 - **Jira/Confluence** → Atlassian MCP
 
 ### Testing
+- **Accessibility Implementation & Audits** → Accessibility Engineer
 - **E2E Browser Tests** → Playwright Expert
 - **All Other Testing** → Test Master
 

--- a/assets/social-preview.html
+++ b/assets/social-preview.html
@@ -262,7 +262,7 @@
             </div>
 
             <!-- Subtitle -->
-            <h2 class="subtitle"><!-- SKILL_COUNT -->67<!-- /SKILL_COUNT --> Specialized Skills and <!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> workflows for Full-Stack Developers</h2>
+            <h2 class="subtitle"><!-- SKILL_COUNT -->68<!-- /SKILL_COUNT --> Specialized Skills and <!-- WORKFLOW_COUNT -->9<!-- /WORKFLOW_COUNT --> workflows for Full-Stack Developers</h2>
 
             <!-- Tagline -->
             <p class="tagline">Transform Claude Code into your expert pair programmer</p>
@@ -277,7 +277,7 @@
                 <div class="stat">
                     <div class="stat-content">
                         <span class="stat-icon">📚</span>
-                        <span><!-- REFERENCE_COUNT -->371<!-- /REFERENCE_COUNT --> Reference Files</span>
+                        <span><!-- REFERENCE_COUNT -->374<!-- /REFERENCE_COUNT --> Reference Files</span>
                     </div>
                 </div>
                 <div class="stat">

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
     starlight({
       title: 'Claude Skills',
       description:
-        '67 specialized skills for Claude Code — progressive disclosure, context engineering, and full-stack coverage.',
+        '68 specialized skills for Claude Code — progressive disclosure, context engineering, and full-stack coverage.',
       customCss: ['./src/styles/custom.css'],
       head: [
         {

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Claude Skills
-description: 67 specialized skills for Claude Code — progressive disclosure, context engineering, and full-stack coverage.
+description: 68 specialized skills for Claude Code — progressive disclosure, context engineering, and full-stack coverage.
 template: splash
 hero:
   tagline: Transform Claude Code into your expert pair programmer across the entire development stack.
@@ -17,14 +17,14 @@ hero:
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
-  <Card title="67 Skills" icon="puzzle">
+  <Card title="68 Skills" icon="puzzle">
     Specialized skills covering 12 domains — languages, frameworks, infrastructure, security, DevOps, data/ML, and more.
   </Card>
   <Card title="9 Workflows" icon="rocket">
     Project workflow commands managing epics from discovery through retrospectives, with Jira and Confluence
     integration.
   </Card>
-  <Card title="371 References" icon="open-book">
+  <Card title="374 References" icon="open-book">
     Deep-dive reference files loaded on-demand for surgical precision when context requires it.
   </Card>
   <Card title="Progressive Disclosure" icon="magnifier">

--- a/skills/accessibility-engineer/SKILL.md
+++ b/skills/accessibility-engineer/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: accessibility-engineer
+description: Builds and audits accessible web interfaces against WCAG 2.2 using semantic HTML, appropriate ARIA, keyboard interaction, focus management, screen-reader checks, and automated tooling. Use when implementing accessible components, reviewing accessibility regressions, remediating audit findings, or validating forms, dialogs, navigation, data tables, and dynamic content.
+license: MIT
+metadata:
+  author: https://github.com/Whxuan0701
+  version: "1.0.0"
+  domain: quality
+  triggers: accessibility, a11y, WCAG 2.2, ARIA, screen reader, keyboard navigation, focus management, axe, accessible forms, color contrast
+  role: expert
+  scope: implementation
+  output-format: analysis-and-code
+  related-skills: test-master, playwright-expert, react-expert
+---
+
+# Accessibility Engineer
+
+Accessibility engineer specializing in standards-based implementation, evidence-driven audits, and durable regression prevention for web interfaces.
+
+## Role Definition
+
+Build and review interfaces for disabled users across keyboard, screen-reader, zoom, contrast, motion, and cognitive-access needs. Treat WCAG success criteria as testable requirements, prefer native platform semantics, and distinguish automated signals from manual conformance evidence.
+
+## When to Use This Skill
+
+- Implementing or reviewing interactive components, forms, navigation, tables, and live updates
+- Investigating keyboard traps, focus loss, inaccessible names, or screen-reader announcement defects
+- Mapping audit findings to WCAG 2.2 success criteria and remediation steps
+- Adding accessibility tests to component, integration, or end-to-end suites
+- Checking responsive reflow, zoom, contrast, target size, reduced motion, and error recovery
+- Preparing an evidence-based accessibility report without claiming legal certification
+
+## Core Workflow
+
+1. **Define scope** - Identify user journeys, target WCAG level, platforms, assistive technologies, and known constraints
+2. **Inspect semantics** - Check document structure, accessible names, roles, states, relationships, and native control use
+3. **Exercise interactions** - Complete each journey with keyboard, zoom/reflow, reduced motion, and representative screen readers
+4. **Automate stable checks** - Add axe and role/name/state assertions while keeping manual-only criteria explicit
+5. **Remediate and verify** - Fix root causes, retest affected journeys, document evidence, and prevent regressions
+
+## Reference Guide
+
+Load detailed guidance based on the task:
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Semantics and ARIA | `references/semantic-aria-patterns.md` | Building or reviewing controls and composite widgets |
+| Test strategy | `references/testing-workflow.md` | Auditing journeys or adding automated/manual tests |
+| Finding remediation | `references/remediation-playbook.md` | Prioritizing, fixing, and reporting accessibility defects |
+
+## Decision Rules
+
+| Situation | Required approach |
+|-----------|-------------------|
+| Native element provides the behavior | Use it before adding ARIA or custom keyboard handling |
+| Custom composite widget is necessary | Follow the matching WAI-ARIA APG interaction pattern |
+| Automated scan reports zero violations | Continue manual keyboard, screen-reader, zoom, and visual checks |
+| Requirement depends on perception or task success | Validate with a human-observable journey, not DOM inspection alone |
+| Finding cannot be fixed immediately | Record impact, evidence, owner, mitigation, and retest condition |
+
+## Audit Coverage
+
+Evaluate the complete state model of each critical journey:
+
+- Initial, loading, empty, populated, error, disabled, and success states
+- Default, hover, focus, active, selected, expanded, checked, and invalid control states
+- Pointer, keyboard, touch, zoom/reflow, reduced-motion, and screen-reader operation
+- Page entry, client-side navigation, overlay open/close, validation, deletion, and recovery transitions
+- Responsive breakpoints, supported themes, localization expansion, and user font or contrast preferences
+
+For each state, verify the perceivable content, operable controls, understandable instructions, and programmatic name/role/value relationships. Sample repeated instances only after confirming they share one implementation.
+
+## Remediation Strategy
+
+Choose fixes in this order:
+
+1. Replace custom behavior with the correct native HTML element
+2. Correct shared component semantics and interaction contracts
+3. Align visible labels, accessible names, descriptions, and error messages
+4. Repair focus movement, reading order, announcements, and recovery behavior
+5. Add narrowly scoped ARIA only for semantics HTML cannot express
+6. Add regression coverage at the lowest stable layer plus manual retest instructions
+
+Do not preserve an inaccessible API solely to avoid a component change. When compatibility prevents an immediate correction, expose a migration path and keep the barrier visible as product risk.
+
+## Severity Model
+
+| Severity | Meaning |
+|----------|---------|
+| Critical | A core task is blocked without a reasonable workaround |
+| High | A core task is substantially obstructed or unreliable |
+| Medium | The task is possible with significant friction or a workaround |
+| Low | A localized issue creates limited but real friction |
+
+Severity reflects user impact, reach, and task importance, not estimated implementation effort.
+
+## Constraints
+
+### MUST DO
+
+- Preserve native semantics and keyboard behavior before adding ARIA
+- Give every interactive control an accurate accessible name and visible focus indicator
+- Keep DOM order, reading order, and focus order aligned with the intended workflow
+- Test dynamic state changes, validation errors, loading states, and route transitions
+- Map findings to specific WCAG 2.2 criteria and include reproducible evidence
+- Separate automated, manual, and assistive-technology test results
+
+### MUST NOT DO
+
+- Use ARIA to repair invalid HTML when a native element solves the problem
+- Add positive `tabindex` values or keyboard handlers that duplicate browser behavior
+- Treat color alone, placeholder text, title attributes, or hover content as sufficient communication
+- Disable zoom, remove focus outlines without replacement, or trap focus outside a modal interaction
+- Claim WCAG conformance from axe, Lighthouse, or another automated scanner alone
+- Hide unresolved blockers behind aggregate accessibility scores
+
+## Output Templates
+
+When implementing or auditing accessibility, provide:
+
+1. Scope and target standard, including tested browsers and assistive technologies
+2. Findings with severity, affected users, WCAG criterion, evidence, and reproduction steps
+3. Focused code changes that preserve behavior and semantics
+4. Automated and manual verification results, with untested areas stated explicitly
+5. Remaining risks, accepted exceptions, and recommended regression coverage
+
+## Knowledge Reference
+
+WCAG 2.2, WAI-ARIA 1.2, ARIA Authoring Practices, Accessible Name and Description Computation, semantic HTML, keyboard interaction, focus management, screen readers, axe-core, Playwright, reflow, contrast, reduced motion
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/accessibility-engineer/)

--- a/skills/accessibility-engineer/references/remediation-playbook.md
+++ b/skills/accessibility-engineer/references/remediation-playbook.md
@@ -1,0 +1,140 @@
+# Accessibility Remediation Playbook
+
+Use this reference to turn an accessibility finding into a prioritized, verifiable engineering change.
+
+## Write an Actionable Finding
+
+Each finding should answer six questions:
+
+1. Which user journey and UI state is affected?
+2. Which users or assistive technologies encounter the barrier?
+3. What exact steps reproduce it?
+4. What happens, and what should happen instead?
+5. Which WCAG 2.2 success criterion or product requirement applies?
+6. What evidence will prove the remediation works?
+
+Example:
+
+> **High - Shipping dialog traps screen-reader context outside the modal**
+>
+> On checkout, activate “Change shipping address” and navigate with VoiceOver. Background checkout controls remain in the virtual cursor order even though the dialog visually obscures them. Keyboard focus is contained, but the rest of the document is not made inert. This blocks reliable dialog navigation and conflicts with WCAG 2.2 SC 1.3.2 and 2.4.3. Apply native `<dialog>` behavior or make the background inert, then verify dialog name, reading order, `Escape`, and focus restoration in Safari/VoiceOver and Chrome/NVDA.
+
+## Prioritize by User Impact
+
+Use severity to communicate task impact, not implementation effort.
+
+| Severity | User impact | Examples |
+|----------|-------------|----------|
+| Critical | Core task cannot be completed and no reasonable workaround exists | Keyboard trap, inaccessible authentication, destructive action without confirmation |
+| High | Core task is substantially blocked or error-prone | Unlabeled required controls, unusable dialog, errors never announced |
+| Medium | Task remains possible with significant friction or a workaround | Illogical focus order, insufficient non-text contrast, missing table headers |
+| Low | Localized friction with limited task impact | Redundant announcement, minor heading inconsistency |
+
+Also record reach, frequency, affected journey importance, and whether the barrier compounds with others. Do not downgrade a severe barrier because few users reported it.
+
+## Fix Root Causes
+
+Prefer changes at the shared component or design-system layer when the defect repeats. Common transformations:
+
+| Symptom | Root-cause remediation |
+|---------|------------------------|
+| Clickable generic element | Replace with native button or link |
+| Missing or unstable name | Add persistent visible label; use ARIA only when necessary |
+| Focus disappears after render | Preserve node identity or explicitly restore focus after state transition |
+| Custom widget keys differ by page | Centralize the APG interaction contract in one component |
+| Error shown only by color | Add text, programmatic invalid state, and error association |
+| Toast is never announced | Use an existing status region and concise message |
+| Motion cannot be disabled | Add reduced-motion behavior that preserves state and meaning |
+| Contrast varies by theme | Correct design tokens and test every component state |
+
+Avoid patches that satisfy a scanner but leave the interaction broken, such as adding `role="button"` without keyboard activation or adding an empty `aria-label`.
+
+## Safe Remediation Sequence
+
+1. Add a focused automated regression test when the behavior is deterministic.
+2. Reproduce the barrier with the original manual or assistive-technology steps.
+3. Implement the smallest semantic or interaction change at the owning layer.
+4. Run component tests and the affected end-to-end journey.
+5. Repeat the original keyboard, screen-reader, zoom, or visual verification.
+6. Scan nearby states for regressions introduced by the change.
+7. Update the finding with evidence, environment, and remaining limitations.
+
+Automation-first is not appropriate when the defect can only be judged through comprehension or assistive-technology output. In that case, document the manual regression procedure alongside the code change.
+
+## Framework Considerations
+
+### React and Component Frameworks
+
+- Keep focusable element identity stable across state changes; avoid changing a button into an unrelated element after activation.
+- Forward refs only when a parent truly owns focus movement.
+- Generate deterministic IDs for label/control and description relationships.
+- Put keyboard behavior in the reusable component, not in each consumer.
+- Announce route and asynchronous state changes deliberately; rendering text does not guarantee announcement.
+
+### Client-Side Routing
+
+After navigation, update the document title and establish a predictable focus destination. Preserve user focus for inline state changes that do not create a new page context. Test browser back/forward navigation and deep links separately.
+
+### Server Rendering and Hydration
+
+Ensure IDs, accessible names, and landmark structure do not change during hydration. A transient duplicate ID or missing label can produce confusing accessibility-tree updates even if the final DOM looks correct.
+
+## Exceptions and Third-Party Barriers
+
+When a barrier cannot be fixed immediately:
+
+- Record the inaccessible behavior and affected journey.
+- Identify the owning dependency or vendor and version.
+- Provide an accessible alternative or mitigation when possible.
+- Set an owner and review date instead of an indefinite waiver.
+- Define the exact condition that will trigger retesting.
+- Keep the exception visible in release risk and procurement decisions.
+
+Do not suppress automated rules globally for one third-party component. Scope exclusions to the smallest known node and retain manual coverage for the affected journey.
+
+## Verification Checklist
+
+Before closing a finding, confirm:
+
+- The original reproduction no longer fails.
+- The fix works with the input and assistive technology that exposed the barrier.
+- Name, role, value, state, and relationships remain accurate.
+- Focus order and reading order remain logical before, during, and after the interaction.
+- Error, loading, empty, success, and disabled states were checked where relevant.
+- Zoom, contrast, target size, motion, and responsive behavior were not regressed.
+- Automated coverage asserts user-observable semantics rather than implementation details.
+- The report names any browser/assistive-technology combinations not tested.
+
+## Report Structure
+
+Use a report that supports both triage and engineering:
+
+```markdown
+## Finding title
+
+- Severity:
+- Journey and state:
+- Affected users:
+- WCAG 2.2 criterion:
+- Environment:
+- Steps to reproduce:
+- Expected behavior:
+- Actual behavior:
+- Evidence:
+- Recommended remediation:
+- Regression coverage:
+- Retest result:
+- Remaining risk:
+```
+
+Avoid vague conclusions such as “screen-reader friendly” or “passes accessibility.” Report the combinations and criteria actually evaluated.
+
+## Definition of Done
+
+A remediation is done when the user-observable barrier is removed, the original evidence is retested, relevant adjacent states are checked, and repeatable coverage exists at the appropriate automated or manual layer. A code merge or zero-violation scan alone is not completion.
+
+## Authoritative References
+
+- WCAG 2.2 quick reference: <https://www.w3.org/WAI/WCAG22/quickref/>
+- Understanding WCAG 2.2: <https://www.w3.org/WAI/WCAG22/Understanding/>
+- WAI planning and managing accessibility: <https://www.w3.org/WAI/planning-and-managing/>

--- a/skills/accessibility-engineer/references/semantic-aria-patterns.md
+++ b/skills/accessibility-engineer/references/semantic-aria-patterns.md
@@ -1,0 +1,155 @@
+# Semantic HTML and ARIA Patterns
+
+Use this reference while building or reviewing the accessibility tree and interaction contract of a web interface.
+
+## Semantics First
+
+Choose the element whose built-in behavior matches the user action.
+
+| Need | Prefer | Avoid |
+|------|--------|-------|
+| Trigger an action | `<button type="button">` | Clickable `<div>` or `<span>` |
+| Navigate to a resource | `<a href="...">` | Button with `location.href` |
+| Choose one option | Radio inputs or native `<select>` | Unstructured clickable list |
+| Toggle a boolean | Checkbox or button with `aria-pressed` | Visual switch with no state |
+| Enter a labeled value | `<label>` associated with an input | Placeholder-only labeling |
+| Group page navigation | `<nav aria-label="...">` | Generic container with links |
+| Present tabular relationships | `<table>` with headers | CSS grid of generic elements |
+
+Native controls provide focusability, activation keys, form behavior, states, and platform mappings. Add ARIA only when the semantic HTML vocabulary cannot express the required widget.
+
+## Accessible Names
+
+Every interactive element needs a stable name that describes its purpose. Prefer visible labels because they help sighted and screen-reader users share the same vocabulary.
+
+```html
+<label for="email">Work email</label>
+<input id="email" name="email" type="email" autocomplete="email" />
+
+<button type="button" aria-label="Close settings">
+  <svg aria-hidden="true" focusable="false"><!-- icon --></svg>
+</button>
+```
+
+Check these failure modes:
+
+- The name is missing, duplicated, or changes unexpectedly between renders.
+- `aria-label` replaces useful visible text with a different phrase.
+- `aria-labelledby` references a missing or hidden-away label.
+- An SVG title leaks into a parent control and creates a repeated name.
+- Voice-control users cannot say the visible label because the accessible name differs.
+
+Use `aria-describedby` for supplementary instructions or errors, not as a replacement for the label.
+
+## Roles, States, and Properties
+
+Expose state at the element that owns the interaction:
+
+```html
+<button
+  type="button"
+  aria-expanded="false"
+  aria-controls="account-menu"
+>
+  Account
+</button>
+<ul id="account-menu" hidden>
+  <li><a href="/profile">Profile</a></li>
+</ul>
+```
+
+Update `aria-expanded` and `hidden` from the same source of truth. Do not announce a state that disagrees with the rendered interface.
+
+Common state contracts:
+
+| Widget | State or relationship |
+|--------|-----------------------|
+| Disclosure/menu trigger | `aria-expanded`, optionally `aria-controls` |
+| Toggle button | `aria-pressed` |
+| Current navigation item | `aria-current="page"` |
+| Invalid field | `aria-invalid="true"` plus associated error text |
+| Busy result region | `aria-busy="true"` while updating |
+| Selected option/tab | `aria-selected` on the owned item |
+
+Do not add redundant roles such as `role="button"` to `<button>`. Avoid `role="presentation"` or `aria-hidden="true"` on focusable content.
+
+## Keyboard Interaction
+
+Match native and APG conventions rather than inventing shortcuts.
+
+| Pattern | Expected keys |
+|---------|---------------|
+| Button | `Enter`, `Space` activate |
+| Link | `Enter` follows link |
+| Dialog | Focus enters, `Tab` stays inside, `Escape` closes when allowed, focus returns |
+| Tabs | Arrow keys move among tabs; activation follows the chosen model |
+| Menu | Arrow keys navigate, `Enter`/`Space` activate, `Escape` closes |
+| Listbox | Arrow keys move active option; selection behavior stays consistent |
+
+Use roving `tabindex` or `aria-activedescendant` only for composite widgets that require one tab stop. Positive `tabindex` values create a second focus order and should not be used.
+
+## Focus Management
+
+Move focus only when the user's context changes and the new location is predictable:
+
+- On dialog open, focus the least destructive meaningful control or dialog heading.
+- On dialog close, return focus to the opener if it still exists.
+- After client-side navigation, move focus to the main heading or main region when the framework does not do so.
+- After deleting the focused item, move focus to the next logical item or a stable container.
+- On validation failure, focus the error summary or first invalid field according to the form design.
+
+Never repeatedly steal focus during typing, asynchronous refreshes, or background notifications.
+
+## Dialog Example
+
+```html
+<button id="open-preferences" type="button">Preferences</button>
+
+<dialog id="preferences" aria-labelledby="preferences-title">
+  <h2 id="preferences-title">Preferences</h2>
+  <form method="dialog">
+    <label><input type="checkbox" name="compact" /> Compact layout</label>
+    <button value="cancel">Cancel</button>
+    <button value="save">Save</button>
+  </form>
+</dialog>
+```
+
+Use the native `<dialog>` API where support requirements permit, then verify initial focus, focus containment, `Escape`, backdrop behavior, and focus restoration. A role alone does not implement any of those behaviors.
+
+## Forms and Errors
+
+Group related controls with `<fieldset>` and `<legend>`. Mark required fields in text as well as programmatically. Keep instructions available after the user begins typing.
+
+```html
+<label for="password">Password</label>
+<p id="password-help">At least 12 characters</p>
+<input
+  id="password"
+  name="password"
+  type="password"
+  aria-describedby="password-help password-error"
+  aria-invalid="true"
+/>
+<p id="password-error">Enter at least 12 characters.</p>
+```
+
+Errors must identify the field and explain how to recover. Do not rely on red borders, transient toasts, or a generic “invalid input” message.
+
+## Dynamic Content
+
+Use live regions sparingly. Prefer status semantics for polite, non-blocking updates and alert semantics only for urgent information.
+
+```html
+<p role="status" aria-live="polite">3 results loaded</p>
+```
+
+Insert or update text inside an existing live region. Avoid announcing entire containers, rapidly changing counters, or duplicated visual and live-region messages.
+
+## Authoritative References
+
+- WCAG 2.2: <https://www.w3.org/TR/WCAG22/>
+- WAI-ARIA 1.2: <https://www.w3.org/TR/wai-aria-1.2/>
+- ARIA Authoring Practices Guide: <https://www.w3.org/WAI/ARIA/apg/>
+- Accessible Name and Description Computation: <https://www.w3.org/TR/accname-1.2/>
+- HTML Accessibility API Mappings: <https://www.w3.org/TR/html-aam-1.0/>

--- a/skills/accessibility-engineer/references/testing-workflow.md
+++ b/skills/accessibility-engineer/references/testing-workflow.md
@@ -1,0 +1,143 @@
+# Accessibility Testing Workflow
+
+Use this reference to combine fast automation with the manual checks needed to evaluate real user journeys.
+
+## Define the Test Matrix
+
+Start from critical journeys, not pages in isolation. For each journey, record:
+
+- Entry point and successful outcome
+- Controls, validation, dialogs, route changes, and asynchronous updates involved
+- Target WCAG level and product-specific accessibility requirements
+- Browser, operating system, viewport, zoom level, and assistive technology
+- Authentication, test data, locale, and feature flags
+
+A practical minimum matrix for a web application includes keyboard-only use, 200% and 400% zoom/reflow, forced or high-contrast modes where supported, reduced motion, and at least one representative desktop screen reader. Product audience and support policy determine additional combinations.
+
+## Automated Checks
+
+Automate deterministic failures early:
+
+- Missing names, invalid ARIA, duplicate IDs, and some structural relationships
+- Color contrast where computed foreground/background values are available
+- Role, name, state, and visibility contracts for interactive controls
+- Focus movement and keyboard activation in stable component behaviors
+- Page title, language, landmarks, headings, and form associations
+
+Automation cannot reliably judge whether alternative text is meaningful, focus order makes sense, instructions are understandable, announcements are useful, or a task is operable with a screen reader.
+
+## Playwright and axe Example
+
+```typescript
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+test('checkout has no automatically detectable WCAG A/AA violations', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByLabel('Email').fill('buyer@example.com');
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+    .analyze();
+
+  expect(results.violations).toEqual([]);
+});
+
+test('validation summary receives focus and links to the invalid field', async ({ page }) => {
+  await page.goto('/checkout');
+  await page.getByRole('button', { name: 'Place order' }).click();
+
+  const summary = page.getByRole('alert', { name: 'There is a problem' });
+  await expect(summary).toBeFocused();
+  await summary.getByRole('link', { name: 'Enter your email' }).click();
+  await expect(page.getByLabel('Email')).toBeFocused();
+});
+```
+
+Scope axe scans to stable UI states. Scan initial, expanded, error, modal, and completion states rather than only the first render. Do not disable rules merely to make CI green; document a verified false positive with the narrowest exclusion and an owner.
+
+## Role-Based Assertions
+
+Prefer user-perceived roles and names over CSS selectors:
+
+```typescript
+const trigger = page.getByRole('button', { name: 'Shipping options' });
+await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+await trigger.click();
+await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+await expect(page.getByRole('region', { name: 'Shipping options' })).toBeVisible();
+```
+
+These assertions catch broken accessible names and states while remaining aligned with assistive technology. They do not prove the complete screen-reader experience.
+
+## Keyboard-Only Pass
+
+For each journey:
+
+1. Reload and put the pointer aside.
+2. Press `Tab` from the browser chrome into the page.
+3. Confirm every operable element receives focus in a meaningful order.
+4. Confirm focus is always visible and not hidden behind sticky content.
+5. Activate controls using their expected keys.
+6. Check composite widgets with their APG arrow-key behavior.
+7. Open and close overlays; verify containment and restoration.
+8. Complete errors and recovery without pointer input.
+9. Confirm no keyboard trap exists, including embedded editors and third-party widgets.
+
+Record the exact key sequence for defects. “Keyboard inaccessible” is not a reproducible finding.
+
+## Screen-Reader Pass
+
+Use the screen reader's browse/read mode and focus/forms mode. Verify:
+
+- Page title, language, landmarks, and heading hierarchy orient the user.
+- Links and controls have unique, purpose-matching names in context.
+- Form fields announce label, role, value, required/invalid state, help, and error.
+- Tables expose captions or labels, headers, and cell relationships.
+- Expanded, selected, pressed, checked, busy, and current states remain accurate.
+- Dialog names and initial focus make sense; closing restores context.
+- Status updates are announced once, at the right priority, without interrupting work.
+- Reading order matches the visual and task order.
+
+Do not infer output from DOM attributes. Listen to the actual announcement because browser and accessibility API mappings affect the result.
+
+## Zoom, Reflow, and Visual Checks
+
+At relevant widths and zoom levels, verify that content reflows without two-dimensional scrolling except where inherently necessary, text does not clip, controls do not overlap, and functionality remains available. Check:
+
+- 200% text resizing and 400% browser zoom/reflow
+- Focus indicators against adjacent colors
+- Text and non-text contrast in default, hover, focus, disabled, and error states
+- Target size and spacing for pointer inputs
+- Content revealed on hover or focus can be dismissed, hovered, and persisted as required
+- Animations respect `prefers-reduced-motion` without removing essential information
+- Orientation is not unnecessarily locked
+
+## Test Evidence
+
+For every executed test, capture:
+
+| Field | Example |
+|-------|---------|
+| Journey | Submit checkout with missing email |
+| Environment | macOS, Safari, VoiceOver, 1440x900 |
+| Method | Keyboard and screen reader |
+| Expected | Error summary receives focus and identifies email error |
+| Actual | Focus remains on submit button; new error is not announced |
+| Criterion | WCAG 2.2 SC 3.3.1 and 4.1.3 |
+| Artifact | Video, screenshot, trace, or exact announcement |
+
+Pass results also need enough evidence to be repeatable. State untested combinations rather than treating them as passes.
+
+## CI Strategy
+
+Run component-level semantic tests close to the code and a small critical-journey axe suite in CI. Keep broader assistive-technology testing in a documented manual cadence unless the chosen platform supports reliable automation. Track scanner version and browser updates so rule changes are visible rather than mistaken for product regressions.
+
+Avoid a single global accessibility score as a gate. Gate on actionable violations and critical task regressions, while reporting manual coverage separately.
+
+## Authoritative and Tool References
+
+- WCAG evaluation overview: <https://www.w3.org/WAI/test-evaluate/>
+- Understanding conformance: <https://www.w3.org/WAI/WCAG22/Understanding/conformance>
+- axe-core rules: <https://github.com/dequelabs/axe-core>
+- Playwright accessibility testing: <https://playwright.dev/docs/accessibility-testing>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "version": "0.4.16",
-  "skillCount": 67,
+  "skillCount": 68,
   "workflowCount": 9,
-  "referenceFileCount": 371
+  "referenceFileCount": 374
 }


### PR DESCRIPTION
## Summary

- add an `accessibility-engineer` skill for WCAG 2.2 implementation, audits, and remediation
- route semantic/ARIA patterns, testing workflows, and remediation guidance through three focused reference files
- add the skill to discovery docs and regenerate repository-managed skill/reference counts

## Motivation

Accessibility is currently covered only as a subtopic of framework and testing skills. This addition provides a dedicated, framework-independent engineering practice for semantic HTML, keyboard interaction, focus management, screen-reader verification, zoom/reflow, contrast, and evidence-based reporting.

The skill explicitly separates automated checks from manual and assistive-technology testing, and it does not treat scanner output as conformance certification.

## Validation

- `python scripts/validate-skills.py --skill accessibility-engineer --format json` (0 errors, 0 warnings)
- `make validate`
- `make test` (12 passed, 0 failed)
- `npx prettier --check 'skills/accessibility-engineer/**/*.md' SKILLS_GUIDE.md CHANGELOG.md README.md QUICKSTART.md ROADMAP.md`
- `npm ci --prefix site`
- `npm run build --prefix site` (100 pages built, including `/skills/quality/accessibility-engineer/`)
- `git diff --check`

## Risks and known gaps

- Assistive-technology combinations remain product-specific; the skill requires callers to state the tested matrix rather than claiming universal coverage.
- Full validation reports the repository's existing cross-reference warnings plus three new one-way relationship warnings. Existing hub skills were intentionally left untouched because curated reciprocal links are a maintainer decision.
- `npm audit` reports the repository's existing five findings; the Astro 7 upgrade is already tracked in #226.
- The site build retains the repository's existing `promql` syntax-highlighting warning.

## Issue linkage

This is an independently proposed enhancement and does not close an existing issue.
