### PR TITLE
feat(validation): enforce documentation backlinks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Validate skills
         run: python scripts/validate-skills.py
 
+      - name: Test skill validators
+        run: python -m unittest scripts/test_validate_skills.py
+
       - name: Validate markdown
         run: python scripts/validate-markdown.py --check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `DocumentationBacklinkChecker` in `scripts/validate-skills.py`: enforces the canonical docs URL derived from each skill's domain and directory, requires it exactly once, and keeps it as the final non-blank line
+
 ### Fixed
 - README banner (capsule-render URL) still displayed 66 skills after the v0.4.16 release; the counts are URL-encoded inside the image URL where no `<!-- SKILL_COUNT -->` marker can live, so `update-docs.py` never touched them. The script now rewrites the banner's `desc=` parameter from computed counts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,7 @@ python scripts/validate-skills.py
 
 The script validates:
 - **YAML frontmatter** - Parsing, required fields (name, description, triggers), format
+- **Documentation backlinks** - Canonical domain/skill URL, uniqueness, and last-line placement
 - **Name format** - Letters, numbers, hyphens only
 - **Description** - Max 1024 chars, must contain "Use when" trigger clause
 - **References** - Directory exists, has files, proper headers

--- a/scripts/test_validate_skills.py
+++ b/scripts/test_validate_skills.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Focused regression tests for skill validation behavior."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+SCRIPT_PATH = Path(__file__).with_name("validate-skills.py")
+SPEC = importlib.util.spec_from_file_location("validate_skills", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+validate_skills = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_skills)
+
+
+class DocumentationBacklinkCheckerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.skill_name = "example-skill"
+        self.skill_dir = Path(self.temp_dir.name) / self.skill_name
+        self.skill_dir.mkdir()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def write_skill(self, body: str) -> None:
+        content = f"""---
+name: {self.skill_name}
+description: Example capability. Use when testing validator behavior.
+metadata:
+  domain: quality
+---
+
+# Example Skill
+
+{body}
+"""
+        (self.skill_dir / "SKILL.md").write_text(content)
+
+    def issues_for(self, body: str):
+        self.write_skill(body)
+        checker = validate_skills.DocumentationBacklinkChecker()
+        return checker.check(self.skill_dir, self.skill_name)
+
+    def test_accepts_one_canonical_backlink_as_last_non_blank_line(self) -> None:
+        issues = self.issues_for(
+            "Guidance.\n\n[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/example-skill/)\n"
+        )
+
+        self.assertEqual([], issues)
+
+    def test_rejects_missing_backlink(self) -> None:
+        issues = self.issues_for("Guidance.\n")
+
+        self.assertEqual("documentation-backlink", issues[0].check)
+        self.assertIn("missing", issues[0].message.lower())
+
+    def test_rejects_backlink_with_wrong_domain_or_slug(self) -> None:
+        issues = self.issues_for(
+            "[Documentation](https://jeffallan.github.io/claude-skills/skills/security/other-skill/)\n"
+        )
+
+        self.assertEqual(1, len(issues))
+        self.assertIn("expected", issues[0].message.lower())
+
+    def test_rejects_content_after_backlink(self) -> None:
+        issues = self.issues_for(
+            "[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/example-skill/)\n\nMore guidance.\n"
+        )
+
+        self.assertEqual(1, len(issues))
+        self.assertIn("last non-blank line", issues[0].message)
+
+    def test_rejects_an_extra_documentation_link(self) -> None:
+        issues = self.issues_for(
+            "[Documentation](https://example.com/old-docs)\n\n"
+            "[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/example-skill/)\n"
+        )
+
+        self.assertEqual(1, len(issues))
+        self.assertIn("appear once", issues[0].message)
+
+    def test_defers_invalid_metadata_shape_to_metadata_checker(self) -> None:
+        (self.skill_dir / "SKILL.md").write_text(
+            f"""---
+name: {self.skill_name}
+description: Example capability. Use when testing validator behavior.
+metadata: invalid
+---
+
+# Example Skill
+"""
+        )
+
+        checker = validate_skills.DocumentationBacklinkChecker()
+
+        self.assertEqual([], checker.check(self.skill_dir, self.skill_name))
+
+
+class ValidatorCompositionTests(unittest.TestCase):
+    def test_registers_backlink_checker_without_changing_workflow_checker(self) -> None:
+        with tempfile.TemporaryDirectory() as skills_dir:
+            validator = validate_skills.SkillValidator(skills_dir=skills_dir)
+
+        self.assertIn(
+            "documentation-backlink",
+            [checker.name for checker in validator.checkers],
+        )
+        self.assertTrue(hasattr(validate_skills.WorkflowDefinitionChecker, "_validate_definition"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -1098,6 +1098,67 @@ class LineCountChecker(BaseChecker):
         return []
 
 
+class DocumentationBacklinkChecker(BaseChecker):
+    """Validates the canonical docs backlink at the end of SKILL.md."""
+
+    name = "documentation-backlink"
+    category = "references"
+    LINK_PATTERN = re.compile(r"^\[Documentation\]\([^)]+\)$")
+
+    def check(self, skill_path: Path, skill_name: str) -> list[ValidationIssue]:
+        result = self._extract_frontmatter(skill_path)
+        if result is None:
+            return []
+
+        metadata = result.frontmatter.get("metadata")
+        if not isinstance(metadata, dict):
+            return []  # MetadataFieldsChecker reports missing or invalid metadata.
+
+        domain = metadata.get("domain")
+        if not isinstance(domain, str) or not domain:
+            return []  # MetadataFieldsChecker reports missing or invalid metadata.
+
+        expected = f"[Documentation](https://jeffallan.github.io/claude-skills/skills/{domain}/{skill_name}/)"
+        lines = result.skill_md.read_text().splitlines()
+        non_blank_lines = [line.strip() for line in lines if line.strip()]
+        backlinks = [line for line in non_blank_lines if self.LINK_PATTERN.fullmatch(line)]
+
+        if not backlinks:
+            return [
+                ValidationIssue(
+                    skill=skill_name,
+                    check=self.name,
+                    severity=Severity.ERROR,
+                    message=f"Canonical Documentation backlink is missing; expected: {expected}",
+                    file=str(result.skill_md),
+                )
+            ]
+
+        if len(backlinks) != 1 or backlinks[0] != expected:
+            return [
+                ValidationIssue(
+                    skill=skill_name,
+                    check=self.name,
+                    severity=Severity.ERROR,
+                    message=f"Documentation backlink must appear once and match expected URL: {expected}",
+                    file=str(result.skill_md),
+                )
+            ]
+
+        if non_blank_lines[-1] != expected:
+            return [
+                ValidationIssue(
+                    skill=skill_name,
+                    check=self.name,
+                    severity=Severity.ERROR,
+                    message="Documentation backlink must be the last non-blank line",
+                    file=str(result.skill_md),
+                )
+            ]
+
+        return []
+
+
 # =============================================================================
 # Workflow Checkers
 # =============================================================================
@@ -2061,6 +2122,7 @@ class SkillValidator:
             ReferenceFileCountChecker(),
             NonStandardHeadersChecker(),
             ReferencePathChecker(),
+            DocumentationBacklinkChecker(),
         ]
 
         # Filter by category if specified


### PR DESCRIPTION
## Summary

- add `DocumentationBacklinkChecker` to derive the canonical docs URL from each skill's domain and directory
- require exactly one `Documentation` link and keep it as the final non-blank line
- cover valid, missing, mismatched, duplicate, misplaced, and malformed-metadata cases with standard-library tests
- run the focused validator tests in CI and document the enforced rule

## Motivation

`CLAUDE.md` already requires every skill to end with one canonical docs backlink, but the validator did not enforce that contract. A wrong domain or renamed skill could therefore create a broken aggregator backlink while the repository validation still passed.

## Validation

- `python -m unittest scripts/test_validate_skills.py` (7 passed)
- `make validate`
- `make test` (12 passed, 0 failed)
- `ruff check scripts/validate-skills.py scripts/test_validate_skills.py`
- `ruff format --check scripts/validate-skills.py scripts/test_validate_skills.py`
- `npx pyright scripts/validate-skills.py scripts/test_validate_skills.py` (0 errors; one environment-only PyYAML source warning)
- `git diff --check`

## Risks and known gaps

- The checker validates repository syntax and URL derivation; it does not make network requests to verify deployed pages.
- Invalid metadata shapes continue to be reported by the existing metadata checker rather than producing duplicate backlink errors.

## Issue linkage

This is an independently proposed validation improvement and does not close an existing issue.
