### PR TITLE
feat(tooling): add skill scaffold generator

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Validate skills
         run: python scripts/validate-skills.py
 
+      - name: Test skill scaffold
+        run: python -m unittest scripts/test_create_skill.py
+
       - name: Validate markdown
         run: python scripts/validate-markdown.py --check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `scripts/create-skill.py`: non-interactive, dry-run-capable scaffolding for repository-standard skill frontmatter, sections, references, and canonical documentation backlinks
+
 ### Fixed
 - README banner (capsule-render URL) still displayed 66 skills after the v0.4.16 release; the counts are URL-encoded inside the image URL where no `<!-- SKILL_COUNT -->` marker can live, so `update-docs.py` never touched them. The script now rewrites the banner's `desc=` parameter from computed counts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,12 +137,13 @@ Every `SKILL.md` MUST end with a single canonical Documentation link pointing ba
 ### When Creating New Skills
 
 1. Check existing skills for overlap
-2. Write SKILL.md with capability + trigger description (no process steps)
-3. Create reference files for deep content (100+ lines)
-4. Add routing table linking topics to references
-5. Append the canonical Documentation backlink as the last line (see Documentation Backlink above)
-6. Test skill triggers with realistic prompts
-7. Update SKILLS_GUIDE.md if adding new domain
+2. Run `python scripts/create-skill.py --help` and scaffold the skill with its domain, author, and capability + trigger description
+3. Replace every scaffold `TODO`; keep process steps out of the description
+4. Create reference files for deep content (100+ lines)
+5. Add routing table linking topics to references
+6. Keep the generated canonical Documentation backlink as the last line (see Documentation Backlink above)
+7. Test skill triggers with realistic prompts
+8. Update SKILLS_GUIDE.md if adding new domain
 
 ### When Modifying Skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,13 @@ git checkout -b fix/your-bug-fix
 
 **For New Skills:**
 ```bash
-# Create skill directory
-mkdir -p skills/my-new-skill
-
-# Create SKILL.md following the structure below
+python scripts/create-skill.py my-new-skill \
+  --domain backend \
+  --author your-github-username \
+  --description "Builds production-ready integrations. Use when implementing or reviewing X."
 ```
+
+The generator creates the repository-standard `SKILL.md` skeleton and an initial reference file. Use `--dry-run` to preview the generated files. Replace every `TODO`, add focused reference content, and update metadata before validation.
 
 #### 4. Test Your Changes
 ```bash
@@ -373,5 +375,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 Contributors will be recognized in:
 - [GitHub contributors page](https://github.com/Jeffallan/claude-skills/graphs/contributors)
 - Release notes for significant contributions
-
 

--- a/scripts/create-skill.py
+++ b/scripts/create-skill.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Create a new skill skeleton that follows this repository's conventions."""
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+
+NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+GITHUB_USER_PATTERN = re.compile(r"^(?!-)(?!.*--)[A-Za-z0-9-]{1,39}(?<!-)$")
+DOMAINS = (
+    "language",
+    "backend",
+    "frontend",
+    "infrastructure",
+    "api-architecture",
+    "quality",
+    "devops",
+    "security",
+    "data-ml",
+    "platform",
+    "specialized",
+    "workflow",
+)
+
+TEMPLATE = """---
+name: {name}
+description: {description}
+license: MIT
+metadata:
+  author: https://github.com/{author}
+  version: "1.0.0"
+  domain: {domain}
+  triggers: TODO
+  role: specialist
+  scope: implementation
+  output-format: code
+  related-skills: TODO
+---
+
+# {title}
+
+TODO: Define the skill's role in one sentence.
+
+## Role Definition
+
+TODO: Describe the expertise and boundaries of this skill.
+
+## When to Use This Skill
+
+- TODO: Add concrete triggering scenarios.
+
+## Core Workflow
+
+1. **Assess** - TODO
+2. **Plan** - TODO
+3. **Implement** - TODO
+4. **Validate** - TODO
+5. **Deliver** - TODO
+
+## Reference Guide
+
+| Topic | Reference | Load When |
+|-------|-----------|-----------|
+| Core guidance | `references/overview.md` | Applying the skill's detailed patterns |
+
+## Constraints
+
+### MUST DO
+
+- TODO
+
+### MUST NOT DO
+
+- TODO
+
+## Output Templates
+
+When completing TODO, provide:
+
+1. TODO
+
+## Knowledge Reference
+
+TODO
+
+[Documentation](https://jeffallan.github.io/claude-skills/skills/{domain}/{name}/)
+"""
+
+REFERENCE_TEMPLATE = """# {title} Reference
+
+Use this file for detailed guidance that should load only when the task requires it.
+
+## When to Load
+
+- TODO: Add specific contexts that require this reference.
+
+## Guidance
+
+TODO: Replace this placeholder with complete, focused guidance and practical examples.
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("name", help="Skill directory name in lowercase hyphen-case")
+    parser.add_argument("--domain", choices=DOMAINS, required=True)
+    parser.add_argument("--description", required=True, help="Capability and 'Use when' trigger description")
+    parser.add_argument("--author", required=True, help="GitHub username credited in skill metadata")
+    parser.add_argument("--output", type=Path, default=Path("skills"), help="Parent directory (default: skills)")
+    parser.add_argument("--dry-run", action="store_true", help="Preview paths and content without writing files")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not NAME_PATTERN.fullmatch(args.name):
+        print("error: name must use lowercase letters, digits, and single hyphens", file=sys.stderr)
+        return 2
+    if "Use when" not in args.description:
+        print("error: description must include a 'Use when' trigger clause", file=sys.stderr)
+        return 2
+    if "\n" in args.description or "\r" in args.description:
+        print("error: description must be a single line", file=sys.stderr)
+        return 2
+    if not GITHUB_USER_PATTERN.fullmatch(args.author):
+        print("error: author must be a valid GitHub username", file=sys.stderr)
+        return 2
+
+    skill_dir = args.output / args.name
+    if skill_dir.exists():
+        print(f"error: refusing to overwrite existing directory: {skill_dir}", file=sys.stderr)
+        return 1
+
+    content = TEMPLATE.format(
+        name=args.name,
+        title=" ".join(part.capitalize() for part in args.name.split("-")),
+        description=json.dumps(args.description),
+        domain=args.domain,
+        author=args.author,
+    )
+
+    if args.dry_run:
+        print(f"Would create {skill_dir / 'SKILL.md'}")
+        print(f"Would create {skill_dir / 'references' / 'overview.md'}")
+        print()
+        print(content)
+        return 0
+
+    references_dir = skill_dir / "references"
+    references_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(content)
+    (references_dir / "overview.md").write_text(
+        REFERENCE_TEMPLATE.format(title=" ".join(part.capitalize() for part in args.name.split("-")))
+    )
+    print(f"Created {skill_dir / 'SKILL.md'}")
+    print(f"Created {references_dir / 'overview.md'}")
+    print(f"Next: replace TODOs, add references, then run python scripts/validate-skills.py --skill {args.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_create_skill.py
+++ b/scripts/test_create_skill.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Behavior tests for the repository skill scaffold command."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("create-skill.py")
+
+
+class CreateSkillTests(unittest.TestCase):
+    def run_cli(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+    def test_creates_repository_template_and_reference_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = self.run_cli(
+                "accessibility-auditor",
+                "--domain",
+                "quality",
+                "--description",
+                "Audits accessible interfaces. Use when checking WCAG conformance.",
+                "--author",
+                "octocat",
+                "--output",
+                output_dir,
+            )
+
+            skill_file = Path(output_dir) / "accessibility-auditor" / "SKILL.md"
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertTrue(skill_file.is_file())
+            reference_file = skill_file.parent / "references" / "overview.md"
+            self.assertTrue(reference_file.is_file())
+            self.assertIn("# Accessibility Auditor Reference", reference_file.read_text())
+            content = skill_file.read_text()
+            self.assertIn("metadata:\n", content)
+            self.assertIn("author: https://github.com/octocat", content)
+            self.assertIn("## Core Workflow", content)
+            self.assertTrue(
+                content.rstrip().endswith(
+                    "[Documentation](https://jeffallan.github.io/claude-skills/skills/quality/accessibility-auditor/)"
+                )
+            )
+
+    def test_dry_run_does_not_create_files(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = self.run_cli(
+                "api-auditor",
+                "--domain",
+                "quality",
+                "--description",
+                "Audits API contracts. Use when reviewing API changes.",
+                "--author",
+                "octocat",
+                "--output",
+                output_dir,
+                "--dry-run",
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertFalse((Path(output_dir) / "api-auditor").exists())
+            self.assertIn("Would create", result.stdout)
+
+    def test_rejects_invalid_name(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = self.run_cli(
+                "Invalid_Name",
+                "--domain",
+                "quality",
+                "--description",
+                "Audits APIs. Use when reviewing API changes.",
+                "--author",
+                "octocat",
+                "--output",
+                output_dir,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("lowercase letters", result.stderr)
+
+    def test_refuses_to_overwrite_existing_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            skill_dir = Path(output_dir) / "api-auditor"
+            skill_dir.mkdir()
+            marker = skill_dir / "keep.txt"
+            marker.write_text("keep")
+
+            result = self.run_cli(
+                "api-auditor",
+                "--domain",
+                "quality",
+                "--description",
+                "Audits APIs. Use when reviewing API changes.",
+                "--author",
+                "octocat",
+                "--output",
+                output_dir,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertEqual("keep", marker.read_text())
+
+    def test_rejects_invalid_github_author(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = self.run_cli(
+                "api-auditor",
+                "--domain",
+                "quality",
+                "--description",
+                "Audits APIs. Use when reviewing API changes.",
+                "--author",
+                "not/a-user",
+                "--output",
+                output_dir,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("GitHub username", result.stderr)
+
+    def test_rejects_multiline_description(self) -> None:
+        with tempfile.TemporaryDirectory() as output_dir:
+            result = self.run_cli(
+                "api-auditor",
+                "--domain",
+                "quality",
+                "--description",
+                "Audits APIs. Use when reviewing APIs.\nrole: injected",
+                "--author",
+                "octocat",
+                "--output",
+                output_dir,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("single line", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a non-interactive `scripts/create-skill.py` command for repository-standard skill skeletons
- generate frontmatter, canonical sections, a routed reference file, and the canonical docs backlink
- support `--dry-run`, safe YAML description quoting, input validation, and refusal to overwrite existing directories
- add six behavior tests, run them in CI, and update authoring instructions

## Motivation

New contributors currently assemble the repository-specific template by hand even though the validator expects a precise metadata and section contract. The generator reduces mechanical errors while deliberately leaving domain guidance as explicit `TODO` content for the author to complete and validate.

## Validation

- `python -m unittest scripts/test_create_skill.py` (6 passed)
- generated a temporary skill containing quoted description text and validated it with `scripts/validate-skills.py` (0 structural errors)
- `make validate`
- `make test` (12 passed, 0 failed)
- `ruff check scripts/create-skill.py scripts/test_create_skill.py`
- `ruff format --check scripts/create-skill.py scripts/test_create_skill.py`
- `npx pyright scripts/create-skill.py scripts/test_create_skill.py` (0 errors, 0 warnings)
- `git diff --check`

## Risks and known gaps

- Generated files are intentionally incomplete: contributors must replace every `TODO`, expand references, and run the repository validator before submission.
- The command creates files only; it does not update counts, `SKILLS_GUIDE.md`, or changelog entries automatically.

## Issue linkage

This is an independently proposed contributor-tooling enhancement and does not close an existing issue.
