### PR TITLE
Fix marketplace name in installation commands

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -10,7 +10,7 @@ Get up and running with the Fullstack Dev Skills Plugin.
 /plugin marketplace add jeffallan/claude-skills
 
 # Install the plugin
-/plugin install fullstack-dev-skills@jeffallan
+/plugin install fullstack-dev-skills@fullstack-dev-skills
 
 # Restart Claude Code when prompted
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ```
 **Then, install the skills:**
 ```bash
-/plugin install fullstack-dev-skills@jeffallan
+/plugin install fullstack-dev-skills@fullstack-dev-skills
 ```
 
 For all installation methods and first steps, see the [**Quick Start Guide**](QUICKSTART.md).

--- a/site/scripts/sync-content.mjs
+++ b/site/scripts/sync-content.mjs
@@ -576,7 +576,7 @@ Transform Claude Code into your expert pair programmer across the entire develop
 \`\`\`
 
 \`\`\`bash
-/plugin install fullstack-dev-skills@jeffallan
+/plugin install fullstack-dev-skills@fullstack-dev-skills
 \`\`\`
 
 ## Stats

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -39,7 +39,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 ```
 
 ```bash
-/plugin install fullstack-dev-skills@jeffallan
+/plugin install fullstack-dev-skills@fullstack-dev-skills
 ```
 
 See the [Getting Started guide](/claude-skills/getting-started/) for all installation methods and first steps.


### PR DESCRIPTION
## Summary

- Use the declared `fullstack-dev-skills` marketplace name in plugin installation examples.
- Keep the README, Quick Start guide, docs landing page, and generated LLM index source consistent.

## Validation

- Verified that `fullstack-dev-skills@jeffallan` fails after adding the marketplace.
- Verified that `fullstack-dev-skills@fullstack-dev-skills` installs successfully with Claude Code 2.1.247.
- Ran skill validation, Markdown validation, documentation sync validation, targeted pre-commit hooks, and the site build.

Fixes #234